### PR TITLE
Fix straightforward Boost deprecation warnings

### DIFF
--- a/applications/dmrg/mps/framework/dmrg/models/alps/model.hpp
+++ b/applications/dmrg/mps/framework/dmrg/models/alps/model.hpp
@@ -38,7 +38,7 @@
 #undef tolower
 #undef toupper
 #include <boost/tokenizer.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/container/flat_map.hpp>
 
 #include "symm_handler.hpp"
@@ -56,7 +56,7 @@ bool safe_is_fermionic(alps::SiteBasisDescriptor<I> const& b, alps::SiteOperator
 {
     using boost::bind;
     std::set<std::string> operator_names = op.operator_names();
-    return std::count_if(operator_names.begin(), operator_names.end(), boost::bind(&alps::SiteBasisDescriptor<I>::is_fermionic, b, _1)) % 2;
+    return std::count_if(operator_names.begin(), operator_names.end(), boost::bind(&alps::SiteBasisDescriptor<I>::is_fermionic, b, boost::placeholders::_1)) % 2;
 }
 
 

--- a/applications/dmrg/mps/framework/dmrg/models/generate_mpo/tagged_mpo_maker_optim.hpp
+++ b/applications/dmrg/mps/framework/dmrg/models/generate_mpo/tagged_mpo_maker_optim.hpp
@@ -41,7 +41,7 @@
 #include "dmrg/models/lattice.h"
 #include "dmrg/models/model.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <string>
 #include <sstream>
 
@@ -145,7 +145,7 @@ namespace generate_mpo
                 prempo[p][make_pair(trivial_left,trivial_left)] = prempo_value_type(model.identity_matrix_tag(lat.get_prop<int>("type",p)), 1.);
             
             typename Model<Matrix, SymmGroup>::terms_type const& terms = model.hamiltonian_terms();
-            std::for_each(terms.begin(), terms.end(), boost::bind(&TaggedMPOMaker<Matrix,SymmGroup>::add_term, this, _1));
+            std::for_each(terms.begin(), terms.end(), boost::bind(&TaggedMPOMaker<Matrix,SymmGroup>::add_term, this, boost::placeholders::_1));
         }
         
         void add_term(term_descriptor term)

--- a/applications/dmrg/mps/framework/dmrg/models/generate_mpo/utils.hpp
+++ b/applications/dmrg/mps/framework/dmrg/models/generate_mpo/utils.hpp
@@ -38,7 +38,7 @@
 #include <string>
 #include <sstream>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace generate_mpo
 {
@@ -59,8 +59,8 @@ namespace generate_mpo
         void canonical_order() // TODO: check and fix for fermions
         {
             std::sort(operators.begin(), operators.end(),
-                      boost::bind(&op_pair_t::first, _1) <
-                      boost::bind(&op_pair_t::first, _2));
+                      boost::bind(&op_pair_t::first, boost::placeholders::_1) <
+                      boost::bind(&op_pair_t::first, boost::placeholders::_2));
         }
         
         bool operator< (Operator_Tag_Term const & rhs) const
@@ -125,8 +125,8 @@ namespace generate_mpo
         void canonical_order() // TODO: check and fix for fermions
         {
             std::sort(operators.begin(), operators.end(),
-                      boost::bind(&op_pair_t::first, _1) <
-                      boost::bind(&op_pair_t::first, _2));
+                      boost::bind(&op_pair_t::first, boost::placeholders::_1) <
+                      boost::bind(&op_pair_t::first, boost::placeholders::_2));
         }
         
         bool operator< (Operator_Term const & rhs) const

--- a/applications/dmrg/mps/framework/dmrg/models/measurement.h
+++ b/applications/dmrg/mps/framework/dmrg/models/measurement.h
@@ -44,6 +44,7 @@
 
 #include <stdexcept>
 
+#include <boost/bind/bind.hpp>
 #include <boost/regex.hpp>
 #include <boost/static_assert.hpp>
 
@@ -198,7 +199,7 @@ template<class Matrix, class SymmGroup>
 bool is_hermitian_meas(std::vector<block_matrix<Matrix, SymmGroup> > const & ops)
 {
     return all_true(ops.begin(), ops.end(),
-                    boost::bind(static_cast<bool (*)(block_matrix<Matrix, SymmGroup> const&)>(&is_hermitian), _1));
+                    boost::bind(static_cast<bool (*)(block_matrix<Matrix, SymmGroup> const&)>(&is_hermitian), boost::placeholders::_1));
 }
 
 template<class Matrix, class SymmGroup>

--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/basis_sector_iterators.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/basis_sector_iterators.h
@@ -30,6 +30,7 @@
 
 #include "dmrg/block_matrix/indexing.h"
 
+#include <boost/bind/bind.hpp>
 #include <boost/operators.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
@@ -104,7 +105,7 @@ private:
     charge total_charge() const
     {
         return std::accumulate(state.begin(), state.end(), SymmGroup::IdentityCharge,
-                               boost::bind(static_cast<charge(*)(charge,charge)>(&SymmGroup::fuse), _1,  boost::bind(getter_fn, _2)) );
+                               boost::bind(static_cast<charge(*)(charge,charge)>(&SymmGroup::fuse), boost::placeholders::_1, boost::bind(getter_fn, boost::placeholders::_2)) );
     }
     
     void advance()

--- a/applications/qmc/dwa/bandstructure.hpp
+++ b/applications/qmc/dwa/bandstructure.hpp
@@ -33,7 +33,7 @@
 #include <boost/multi_array.hpp>
 #include <alps/numeric/vector_functions.hpp>
 #include <alps/ngs/boost_python.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <alps/python/numpy_array.hpp>
 

--- a/applications/qmc/dwa/python/dwa.cpp
+++ b/applications/qmc/dwa/python/dwa.cpp
@@ -29,7 +29,7 @@
 
 
 #include <alps/ngs/boost_python.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <alps/python/numpy_array.hpp>
 

--- a/src/alps/alea/simpleobseval.h
+++ b/src/alps/alea/simpleobseval.h
@@ -757,7 +757,7 @@ OBSERVABLE_FUNCTION(tan)
 
 namespace detail {
 
-template <class T> struct function_pow : public std::unary_function<T,double>
+template <class T> struct function_pow
 {
   function_pow(double p) : pow_(p) {}
   T operator()(T x) const { using std::pow; return pow(x, pow_); }

--- a/src/alps/ngs/cast.hpp
+++ b/src/alps/ngs/cast.hpp
@@ -32,7 +32,7 @@
 #include <alps/ngs/config.hpp>
 #include <alps/ngs/stacktrace.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/mpl/int.hpp>
 #include <boost/filesystem/path.hpp>
 

--- a/src/alps/ngs/detail/export_sim_to_python.hpp
+++ b/src/alps/ngs/detail/export_sim_to_python.hpp
@@ -33,7 +33,7 @@
 
 #include <alps/python/make_copy.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/python/dict.hpp>
 #include <boost/python/wrapper.hpp>
 #include <boost/python/return_internal_reference.hpp>

--- a/src/alps/ngs/detail/tcpsession.hpp
+++ b/src/alps/ngs/detail/tcpsession.hpp
@@ -29,7 +29,7 @@
 #ifndef ALPS_NGS_DETAIL_TCPSESSION_HPP
 #define ALPS_NGS_DETAIL_TCPSESSION_HPP
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/asio.hpp>
 #include <boost/lexical_cast.hpp>
 

--- a/src/alps/ngs/lib/params.cpp
+++ b/src/alps/ngs/lib/params.cpp
@@ -30,7 +30,8 @@
 
 #include <alps/parameter.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 
 #include <algorithm>
 

--- a/src/alps/ngs/numeric/vector.hpp
+++ b/src/alps/ngs/numeric/vector.hpp
@@ -41,7 +41,7 @@
 #include <boost/throw_exception.hpp>
 #include <boost/lambda/lambda.hpp>
 #include <boost/lambda/bind.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <vector>
 #include <algorithm>

--- a/src/alps/ngs/python/mcbase.cpp
+++ b/src/alps/ngs/python/mcbase.cpp
@@ -40,7 +40,7 @@
     #include <boost/mpi.hpp>
 #endif
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/python/dict.hpp>
 #include <boost/python/wrapper.hpp>
 #include <boost/python/return_internal_reference.hpp>

--- a/src/alps/ngs/scheduler/proto/tcpserver.hpp
+++ b/src/alps/ngs/scheduler/proto/tcpserver.hpp
@@ -31,7 +31,7 @@
 
 #include <alps/ngs/detail/tcpsession.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/asio.hpp>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>

--- a/src/alps/ngs/scheduler/tcpserver.hpp
+++ b/src/alps/ngs/scheduler/tcpserver.hpp
@@ -31,7 +31,7 @@
 
 #include <alps/ngs/detail/tcpsession.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/asio.hpp>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>

--- a/src/alps/numeric/fourier.hpp
+++ b/src/alps/numeric/fourier.hpp
@@ -35,7 +35,7 @@
 #include <alps/numeric/vector_functions.hpp>
 
 #include <boost/iterator/counting_iterator.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/lambda/lambda.hpp>
 
 

--- a/src/alps/numeric/functional.hpp
+++ b/src/alps/numeric/functional.hpp
@@ -38,62 +38,62 @@
 
 namespace alps { 
     namespace numeric {
-        template <typename T> struct unary_minus : public std::unary_function<T, T> {
+        template <typename T> struct unary_minus {
             T operator()(T const & x) const {
                 using boost::numeric::operators::operator-;
-                return -x; 
+                return -x;
             }
         };
 
-        template <typename T, typename U, typename R> struct plus : public std::binary_function<T, U, R> {
+        template <typename T, typename U, typename R> struct plus {
             R operator()(T const & x, U const & y) const {
                 using boost::numeric::operators::operator+;
-                return x + y; 
+                return x + y;
             }
         };
-        template <typename T> struct plus<T, T, T> : public std::binary_function<T, T, T> {
+        template <typename T> struct plus<T, T, T> {
             T operator()(T const & x, T const & y) const {
                 using boost::numeric::operators::operator+;
-                return x + y; 
+                return x + y;
             }
         };
 
-        template <typename T, typename U, typename R> struct minus : public std::binary_function<T, U, R> {
+        template <typename T, typename U, typename R> struct minus {
             R operator()(T const & x, U const & y) const {
                 using boost::numeric::operators::operator-;
-                return x - y; 
+                return x - y;
             }
         };
-        template <typename T> struct minus<T, T, T> : public std::binary_function<T, T, T> {
+        template <typename T> struct minus<T, T, T> {
             T operator()(T const & x, T const & y) const {
                 using boost::numeric::operators::operator-;
-                return x - y; 
+                return x - y;
             }
         };
 
-        template <typename T, typename U, typename R> struct multiplies : public std::binary_function<T, U, R> {
+        template <typename T, typename U, typename R> struct multiplies {
             R operator()(T const & x, U const & y) const {
                 using boost::numeric::operators::operator*;
-                return x * y; 
+                return x * y;
             }
         };
-        template <typename T> struct multiplies<T, T, T> : public std::binary_function<T, T, T> {
+        template <typename T> struct multiplies<T, T, T> {
             T operator()(T const & x, T const & y) const {
                 using boost::numeric::operators::operator*;
-                return x * y; 
+                return x * y;
             }
         };
 
-        template <typename T, typename U, typename R> struct divides : public std::binary_function<T, U, R> {
+        template <typename T, typename U, typename R> struct divides {
             R operator()(T const & x, U const & y) const {
                 using boost::numeric::operators::operator/;
-                return x / y; 
+                return x / y;
             }
         };
-        template <typename T> struct divides<T, T, T> : public std::binary_function<T, T, T> {
+        template <typename T> struct divides<T, T, T> {
             T operator()(T const & x, T const & y) const {
                 using boost::numeric::operators::operator/;
-                return x / y; 
+                return x / y;
             }
         };
     } 

--- a/src/alps/numeric/polynomial.hpp
+++ b/src/alps/numeric/polynomial.hpp
@@ -35,7 +35,7 @@
 #include <alps/numeric/vector_functions.hpp>
 
 #include <boost/iterator/counting_iterator.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/lambda/lambda.hpp>
 
 

--- a/src/alps/numeric/sequence_comparisons.hpp
+++ b/src/alps/numeric/sequence_comparisons.hpp
@@ -34,7 +34,7 @@
 
 #include <boost/utility/enable_if.hpp>
 #include <boost/lambda/lambda.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <algorithm>
 

--- a/src/alps/python/numpy_import.hpp
+++ b/src/alps/python/numpy_import.hpp
@@ -38,8 +38,10 @@
     #include <boost/python/numeric.hpp>
 #endif
 
-// this should be set to the latest numpy version we have tested
+// Allow callers to pin an earlier API version; default to the latest we have tested.
+#ifndef NPY_NO_DEPRECATED_API
 #define NPY_NO_DEPRECATED_API NPY_1_11_API_VERSION
+#endif
 #include <numpy/arrayobject.h>
 
 namespace alps {


### PR DESCRIPTION
## Summary

Three categories of trivially-safe deprecation warnings eliminated, identified by building on macOS with Apple Clang 21 / Boost 1.87:

### 1. `std::unary_function` / `std::binary_function` — deprecated C++11, removed C++17 (~40 warnings)
- **`src/alps/numeric/functional.hpp`**: remove the base class from all 9 functors (`unary_minus`, `plus`, `minus`, `multiplies`, `divides` and their specialisations). Verified that none of the `result_type`/`argument_type` typedefs they would have provided are accessed anywhere in the codebase.
- **`src/alps/alea/simpleobseval.h`**: remove the base class from `detail::function_pow`. The functor is passed by value to `transform()`, which doesn't require those typedefs.

### 2. `NPY_NO_DEPRECATED_API` macro redefined — 94 warnings per translation unit
- **`src/alps/python/numpy_import.hpp`**: wrap the `#define` in `#ifndef` so that an earlier definition (from Boost Python headers) is not silently overwritten.

### 3. `<boost/bind.hpp>` global-placeholder deprecation — fires per translation unit that transitively includes the old header
Boost ≥ 1.77 warns that placing `_1`, `_2`, … in the global namespace via `<boost/bind.hpp>` is deprecated. The canonical fix is to use `<boost/bind/bind.hpp>`. Applied to all 16 ALPS files that included the old header directly:
- **Files with no bare `_1`/`_2`** (11 files): one-line include swap only.
- **`.cpp` files with bare `_1`/`_2`** (`params.cpp`): include swap + `using namespace boost::placeholders;` at file scope.
- **Header files with bare `_1`/`_2`** (`tagged_mpo_maker_optim.hpp`, `utils.hpp`, `model.hpp`): include swap + each placeholder qualified as `boost::placeholders::_1` etc. to avoid polluting includers' namespaces.

## What was intentionally left out
- `op_assign_vector.hpp`: the `binary_function` base is entangled with `std::bind2nd` — fixing it requires replacing `bind2nd` with a lambda, not a one-liner.
- `src/boost/numeric/bindings/`: bundled Boost headers with thousands of unused-typedef warnings — separate concern.
- `std::bind1st`/`bind2nd` sites in `multi_array/` and elsewhere.
- `assigning field to itself` warnings — potential semantic bugs needing separate review.

## Test plan
- [ ] Clean build on Linux (GCC) passes without the fixed warnings
- [ ] Clean build on macOS (Apple Clang + Boost 1.87) passes without the fixed warnings
- [ ] Existing test suite (`cmake --build alps-build -t test`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)