### PR TITLE
Remove obsolete Mavericks-era -stdlib=libstdc++ forced flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,11 +176,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive  -DBOOST_NO_AUTO_PTR -DBOOS
 STRING(REGEX MATCH "clang" IS_CLANG "${ALPS_COMPILER_VERSION}")
 if(IS_CLANG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-depth-256 -Wall -Wno-unknown-pragmas -Wno-unused-function -Wno-overloaded-virtual -Wno-unneeded-internal-declaration -Wno-unused-variable -Wno-return-type-c-linkage")
-    if(NOT ${CMAKE_CXX_FLAGS} MATCHES "-(std=c\\+\\+11|stdlib=)")
-        # compilation fails with -stdlib=libc++, which is new default on Mavericks
-        message(STATUS "Forcing -stdlib=libstdc++. If you want to override this decision explicitly add -stdlib=libc++ or -std=c++11 to CMAKE_CXX_FLAGS.")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
-    endif(NOT ${CMAKE_CXX_FLAGS} MATCHES "-(std=c\\+\\+11|stdlib=)")
 endif(IS_CLANG)
 
 # For gfortran 10 (see https://gcc.gnu.org/gcc-10/changes.html)


### PR DESCRIPTION
## Summary

- The 2013-era block that forced `-stdlib=libstdc++` on any Clang was added to work around a libc++ incompatibility introduced in OS X Mavericks (10.9).
- Apple removed `libstdc++` headers entirely in Xcode 10 (2018), so the forced flag now breaks every build on modern macOS with `fatal error: 'cstddef' file not found`.
- The workaround has been to pass `-stdlib=libc++` manually in `CMAKE_CXX_FLAGS` to trip the guard and prevent the forced injection — a confusing requirement that is now unnecessary.
- Both Linux Clang (defaults to `libstdc++`) and Apple Clang (defaults to `libc++`) pick the right library automatically; no explicit `-stdlib=` flag is needed in either case.

## Test plan

- [x] `cmake` configure on macOS without any `-stdlib=` flag — no "Forcing -stdlib=libstdc++" message, configures cleanly
- [x] Full build on macOS succeeds without passing `-stdlib=libc++` manually
- [x] CI passes on Linux (Clang defaults to `libstdc++` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)