### PR TITLE
Fix removed std::ptr_fun, std::bind1st/bind2nd in multi_array

### DIFF
--- a/src/alps/multi_array/functions.hpp
+++ b/src/alps/multi_array/functions.hpp
@@ -76,8 +76,7 @@ ALPS_IMPLEMENT_FUNCTION(cbrt)
     template <class T1, class T2, std::size_t D, class Allocator>
     multi_array<T1,D,Allocator> pow(multi_array<T1,D,Allocator> a, T2 s)
   {
-    std::pointer_to_binary_function <T1,T2,T1> PowObject (boost::ptr_fun<T1,T2,T1>(std::pow));
-    std::transform(a.data(),a.data()+a.num_elements(),a.data(),boost::bind2nd(PowObject,s));
+    std::transform(a.data(),a.data()+a.num_elements(),a.data(),[s](T1 x){ return std::pow(x, s); });
     return a;
   }
 

--- a/src/alps/multi_array/functions.hpp
+++ b/src/alps/multi_array/functions.hpp
@@ -32,13 +32,14 @@
 
 #include <alps/multi_array/multi_array.hpp>
 #include <alps/numeric/special_functions.hpp>
+#include <boost/functional.hpp>
 
 namespace alps {
 
 #define ALPS_IMPLEMENT_FUNCTION(FUN)                                                                                            \
     template <class T, std::size_t D, class Allocator> multi_array<T,D,Allocator> FUN (multi_array<T, D, Allocator> arg) {      \
         using std:: FUN;                                                                                                        \
-        std::transform(arg.data(), arg.data() + arg.num_elements(), arg.data(), std::ptr_fun<T, T>(FUN));                       \
+        std::transform(arg.data(), arg.data() + arg.num_elements(), arg.data(), boost::ptr_fun<T, T>(FUN));                       \
         return arg;                                                                                                             \
     }
 
@@ -62,7 +63,7 @@ ALPS_IMPLEMENT_FUNCTION(fabs)
 #define ALPS_IMPLEMENT_FUNCTION(FUN)                                                                                            \
     template <class T, std::size_t D, class Allocator> multi_array<T, D, Allocator> FUN (multi_array<T, D, Allocator> arg) {    \
         using alps::numeric:: FUN ;                                                                                             \
-        std::transform(arg.data(), arg.data() + arg.num_elements(), arg.data(), std::ptr_fun<T, T>(FUN));                       \
+        std::transform(arg.data(), arg.data() + arg.num_elements(), arg.data(), boost::ptr_fun<T, T>(FUN));                       \
         return arg;                                                                                                             \
     }
 
@@ -75,8 +76,8 @@ ALPS_IMPLEMENT_FUNCTION(cbrt)
     template <class T1, class T2, std::size_t D, class Allocator>
     multi_array<T1,D,Allocator> pow(multi_array<T1,D,Allocator> a, T2 s)
   {
-    std::pointer_to_binary_function <T1,T2,T1> PowObject (std::ptr_fun<T1,T2,T1>(std::pow));
-    std::transform(a.data(),a.data()+a.num_elements(),a.data(),std::bind2nd(PowObject,s));
+    std::pointer_to_binary_function <T1,T2,T1> PowObject (boost::ptr_fun<T1,T2,T1>(std::pow));
+    std::transform(a.data(),a.data()+a.num_elements(),a.data(),boost::bind2nd(PowObject,s));
     return a;
   }
 

--- a/src/alps/multi_array/multi_array.hpp
+++ b/src/alps/multi_array/multi_array.hpp
@@ -31,6 +31,7 @@
 #define ALPS_MULTI_ARRAY_BASE_HPP
 
 #include <boost/multi_array.hpp>
+#include <boost/functional.hpp>
 
 namespace alps{
 

--- a/src/alps/multi_array/multi_array.hpp
+++ b/src/alps/multi_array/multi_array.hpp
@@ -99,7 +99,7 @@ namespace alps{
 
         array_type& operator+=(const T s)
         {
-            std::transform((*this).data(),(*this).data()+(*this).num_elements(),(*this).data(),std::bind2nd(std::plus<T>(),s));
+            std::transform((*this).data(),(*this).data()+(*this).num_elements(),(*this).data(),boost::bind2nd(std::plus<T>(),s));
             return *this;
         }
 
@@ -112,7 +112,7 @@ namespace alps{
 
         array_type& operator-=(const T s)
         {
-            std::transform((*this).data(),(*this).data()+(*this).num_elements(),(*this).data(),std::bind2nd(std::minus<T>(),s));
+            std::transform((*this).data(),(*this).data()+(*this).num_elements(),(*this).data(),boost::bind2nd(std::minus<T>(),s));
             return *this;
         }
 
@@ -125,7 +125,7 @@ namespace alps{
 
         array_type& operator*=(const T s)
         {
-            std::transform((*this).data(),(*this).data()+(*this).num_elements(),(*this).data(),std::bind2nd(std::multiplies<T>(),s));
+            std::transform((*this).data(),(*this).data()+(*this).num_elements(),(*this).data(),boost::bind2nd(std::multiplies<T>(),s));
             return *this;
         }
 
@@ -138,7 +138,7 @@ namespace alps{
 
         array_type& operator/=(const T s)
         {
-            std::transform((*this).data(),(*this).data()+(*this).num_elements(),(*this).data(),std::bind2nd(std::divides<T>(),s));
+            std::transform((*this).data(),(*this).data()+(*this).num_elements(),(*this).data(),boost::bind2nd(std::divides<T>(),s));
             return *this;
         }
 

--- a/src/alps/multi_array/operators.hpp
+++ b/src/alps/multi_array/operators.hpp
@@ -118,7 +118,7 @@ namespace alps{
   template <class T1, class T2, std::size_t D, class Allocator>
   multi_array<T2,D,Allocator> operator/(T2 const & scalar, multi_array<T1,D,Allocator> array)
   {
-    std::transform(array.data(), array.data() + array.num_elements(), array.data(), std::bind1st(std::divides<T1>(),T1(scalar)));
+    std::transform(array.data(), array.data() + array.num_elements(), array.data(), std::bind(std::divides<T1>(),T1(scalar), std::placeholders::_1));
     return array;
   }
 


### PR DESCRIPTION
## Summary

`std::ptr_fun`, `std::bind1st`, and `std::bind2nd` were deprecated in C++11 and removed in C++17, causing compilation failures with modern compilers.

- `functions.hpp`, `multi_array.hpp`: replace `std::ptr_fun` / `std::bind2nd` with `boost::ptr_fun` / `boost::bind2nd`, consistent with the surrounding Boost-based code
- `operators.hpp`: replace `std::bind1st` with `std::bind` + `std::placeholders::_1`

Follows the same pattern as #46 (boost deprecation warnings), but for the `multi_array` layer.

## Test plan

- [ ] Build succeeds without deprecation warnings on the affected files
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)