### PR TITLE
Upgrade actions/setup-python from v3 to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.plat.py_version }}
       - name: Install dependencies


### PR DESCRIPTION
## Summary

All Ubuntu CI jobs are failing at the "Set up Python" step with:

```
candidates is not iterable
```

This is a known issue with `actions/setup-python@v3`: the GitHub-hosted Python version manifest format changed and v3 cannot parse it. The fix is to upgrade to v5, which is the current stable release.

The failure was pre-existing on `master` and is not related to any code change — it affects every PR and every push.

## Test plan

- [ ] Ubuntu CI jobs pass the "Set up Python" step after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)