### PR TITLE
Remove self-assignment of bare_green_matsubara in interaction_expansion

### DIFF
--- a/applications/dmft/qmc/interaction_expansion/interaction_expansion.cpp
+++ b/applications/dmft/qmc/interaction_expansion/interaction_expansion.cpp
@@ -90,7 +90,6 @@ InteractionExpansionRun::InteractionExpansionRun(const alps::ProcessList &where,
   if(!parms.defined("ATOMIC")) {
     std::istringstream in_omega(parms["G0(omega)"]);
     read_freq(in_omega, bare_green_matsubara);
-    bare_green_matsubara = bare_green_matsubara;
     FourierTransformer::generate_transformer(parms, fourier_ptr);
     fourier_ptr->backward_ft(bare_green_itime, bare_green_matsubara);
   }


### PR DESCRIPTION
## Summary

- `interaction_expansion.cpp:93` assigned `bare_green_matsubara` to itself immediately after correctly populating it via `read_freq`. The line was a no-op, flagged by `-Wself-assign-field`.

## Test plan

- [ ] Build succeeds without `-Wself-assign-field` warning on this line
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)