### PR TITLE
Remove unused step counter in interaction_expansion solver

### DIFF
--- a/applications/dmft/qmc/interaction_expansion/interaction_expansion.cpp
+++ b/applications/dmft/qmc/interaction_expansion/interaction_expansion.cpp
@@ -90,7 +90,6 @@ InteractionExpansionRun::InteractionExpansionRun(const alps::ProcessList &where,
   if(!parms.defined("ATOMIC")) {
     std::istringstream in_omega(parms["G0(omega)"]);
     read_freq(in_omega, bare_green_matsubara);
-    bare_green_matsubara = bare_green_matsubara;
     FourierTransformer::generate_transformer(parms, fourier_ptr);
     fourier_ptr->backward_ft(bare_green_itime, bare_green_matsubara);
   }

--- a/applications/dmft/qmc/interaction_expansion/solver.cpp
+++ b/applications/dmft/qmc/interaction_expansion/solver.cpp
@@ -37,7 +37,6 @@ void InteractionExpansionRun::interaction_expansion_step(void)
   int pert_order=vertices.size();   //current order of perturbation series
   double metropolis_weight=0.;
   //double oldsign=sign;
-  static unsigned int i=0; ++i;    
   if(random_01()<0.5){  //trying to ADD vertex
     if(vertices.size()>=max_order) 
       return; //we have already reached the highest perturbation order

--- a/applications/dmft/qmc/interaction_expansion2/solver.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/solver.cpp
@@ -37,7 +37,6 @@ void InteractionExpansion::interaction_expansion_step(void)
   int pert_order=vertices.size();   //current order of perturbation series
   double metropolis_weight=0.;
   //double oldsign=sign;
-  static unsigned int i=0; ++i;    
   if(random()<0.5){  //trying to ADD vertex
     if(vertices.size()>=max_order) 
       return; //we have already reached the highest perturbation order


### PR DESCRIPTION
## Summary

Both `interaction_expansion` and `interaction_expansion2` had a `static unsigned int i` that was incremented on every Monte Carlo step but never read — a debug counter left behind, flagged by `-Wunused-but-set-variable`.

## Test plan

- [ ] Build succeeds without `-Wunused-but-set-variable` warnings in these files
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)