### PR TITLE
Remove unused variables 'first' and 'bmask' in dmtk/system.h

### DIFF
--- a/applications/dmrg/dmrg/dmtk/system.h
+++ b/applications/dmrg/dmrg/dmtk/system.h
@@ -1968,10 +1968,9 @@ System<T>::truncate(int position, int new_size)
     for(biter = rho.begin(); biter != rho.end(); biter++){
       SubMatrix<T> &block(*biter);
       bool found = false;
-      bool first = false;
       for(ib = 0; ib < bsize; ib++){
         SubMatrix<T> *_block = bvector(bidx(ib));
-        if(_block == &block) { found = true; first = (ib == 0); break; }
+        if(_block == &block) { found = true; break; }
       }
       if(!found) continue; 
 
@@ -3158,7 +3157,6 @@ System<T>::measure(const VectorState<T> *v)
       res = T(0);
       for(int ib = 0; ib < 4; ib++) aux_term[ib].clear();
       bool found = true;
-      int bmask = 0;
       for(int i = 0; i < t.size(); i++){
         BasicOp<T> top = t[i];
         if(block(top.site()) == BLOCK_NONE){
@@ -3168,7 +3166,6 @@ System<T>::measure(const VectorState<T> *v)
         for(int ib = 1; ib <= 4; ib++){
           if(block(top.site()) == (size_t)ib){
             aux_term[ib-1] *= top;
-            bmask |= mask((size_t)ib);
           }
         }
       } 


### PR DESCRIPTION
## Summary

Two unused variables in `applications/dmrg/dmrg/dmtk/system.h`, both flagged by `-Wunused-but-set-variable`:

- **`first`** (line 1971): set inside the block-search loop (`first = (ib == 0)`) but never read afterward — the subsequent logic uses `first_col` instead.
- **`bmask`** (line 3161): accumulated via `|=` in the operator loop but never consumed anywhere after the loop.

## Test plan

- [ ] Build succeeds without `-Wunused-but-set-variable` warnings on these lines
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)