### PR TITLE
Remove unused 'term_t' typedef in make_exp_mpo (te_utils.hpp)

### DIFF
--- a/applications/dmrg/mps/framework/dmrg/evolve/te_utils.hpp
+++ b/applications/dmrg/mps/framework/dmrg/evolve/te_utils.hpp
@@ -333,7 +333,6 @@ MPO<Matrix, SymmGroup> make_exp_mpo(Lattice const& lat, Model<Matrix, SymmGroup>
                                     std::vector<term_descriptor<typename Matrix::value_type> > const& hamil_terms,
                                     typename Matrix::value_type const & alpha = 1)
 {
-    typedef term_descriptor<typename Matrix::value_type> term_t;
     typedef OPTable<Matrix, SymmGroup> op_table_t;
     typedef boost::shared_ptr<op_table_t> op_table_ptr;
     typedef typename op_table_t::tag_type tag_type;


### PR DESCRIPTION
## Summary

`make_exp_mpo` declared `typedef term_descriptor<typename Matrix::value_type> term_t` but never referenced the alias in the function body — `hamil_terms` is already typed via the parameter and `add_term` is called directly. Flagged by `-Wunused-local-typedef`.

## Test plan

- [ ] Build succeeds without `-Wunused-local-typedef` warning on this line
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)