### PR TITLE
Fix misleading indentation in Operator_Tag_Term operator<< (utils.hpp)

### DIFF
--- a/applications/dmrg/mps/framework/dmrg/models/generate_mpo/utils.hpp
+++ b/applications/dmrg/mps/framework/dmrg/models/generate_mpo/utils.hpp
@@ -105,7 +105,7 @@ namespace generate_mpo
         os << "operators:";
         for (int i=0; i<op.operators.size(); ++i)
             os << " {"  << op.operators[i].first << "," << op.operators[i].second << "}";
-            os << std::endl;
+        os << std::endl;
         return os;
     }
     


### PR DESCRIPTION
## Summary

In `generate_mpo/utils.hpp`, `os << std::endl` was indented to suggest it was inside the `for` loop body, but without braces it executed only once after the loop — which is actually the correct behaviour (one newline after the full operator list). Fixed the indentation to match the real control flow and silence `-Wmisleading-indentation`.

## Test plan

- [ ] Build succeeds without `-Wmisleading-indentation` warning on this line
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)