### PR TITLE
Remove unused 'measurements_container' typedef in operators_for_meas

### DIFF
--- a/applications/dmrg/mps/framework/dmrg/models/measurements.h
+++ b/applications/dmrg/mps/framework/dmrg/models/measurements.h
@@ -56,7 +56,6 @@ namespace measurements {
                            Model<Matrix, SymmGroup> const& model,
                            bool repeat_one=false)
         {
-            typedef boost::ptr_vector<measurement<Matrix, SymmGroup> > measurements_container;
             typedef typename Model<Matrix, SymmGroup>::op_t op_t;
             typedef std::vector<op_t> op_vec;
             typedef std::vector<std::pair<op_vec, bool> > meas_operators_type;


### PR DESCRIPTION
## Summary

`measurements_container` was declared inside `operators_for_meas` but never referenced there. The same type alias exists at class scope (line 145) where it is actually used. Flagged by `-Wunused-local-typedef`.

## Test plan

- [ ] Build succeeds without `-Wunused-local-typedef` warning on this line
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)