### PR TITLE
Remove unused 'overlap_func' typedef in local_at.h

### DIFF
--- a/applications/dmrg/mps/framework/dmrg/models/measurements/local_at.h
+++ b/applications/dmrg/mps/framework/dmrg/models/measurements/local_at.h
@@ -103,8 +103,6 @@ namespace measurements {
                 } else {
                     typename MPS<Matrix, SymmGroup>::scalar_type nn = dm_trace(mps, this->phys_psi);
                     MPS<Matrix, SymmGroup> super_mpo = mpo_to_smps(mpo, this->phys_psi);
-                    // static_cast needed for icpc 12.x
-                    typedef typename MPS<Matrix, SymmGroup>::scalar_type (*overlap_func)(MPS<Matrix, SymmGroup> const &, MPS<Matrix, SymmGroup> const &);
                     typename MPS<Matrix, SymmGroup>::scalar_type val = ::overlap(super_mpo, mps);
                     this->vector_results.push_back(val/nn);
                 }


### PR DESCRIPTION
## Summary

The `overlap_func` function-pointer typedef was a workaround for an overload-resolution bug in icpc 12.x, but `::overlap` was never actually called through it — the direct call on the next line made the typedef a no-op. Flagged by `-Wunused-local-typedef`.

## Test plan

- [ ] Build succeeds without `-Wunused-local-typedef` warning on this line
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)