### PR TITLE
Remove unused 'row_proxy' typedef in lbtm_kernel (contractions.h)

### DIFF
--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
@@ -107,7 +107,6 @@ struct contraction {
                 ProductBasis<SymmGroup> const & out_left_pb)
     {
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::index_type index_type;
-        typedef typename MPOTensor<OtherMatrix, SymmGroup>::row_proxy row_proxy;
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::col_proxy col_proxy;
 
         typedef typename SymmGroup::charge charge;


### PR DESCRIPTION
## Summary

`lbtm_kernel` only iterates over MPO columns (`col_proxy`) — it never iterates over rows. The `row_proxy` typedef was declared but unused, while the sibling `rbtm_kernel` correctly uses both. Flagged by `-Wunused-local-typedef`.

## Test plan

- [ ] Build succeeds without `-Wunused-local-typedef` warning on this line
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)