### PR TITLE
Remove unused 'col_proxy' typedef in rbtm_kernel (contractions.h)

### DIFF
--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
@@ -186,7 +186,6 @@ struct contraction {
     {
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::index_type index_type;
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::row_proxy row_proxy;
-        typedef typename MPOTensor<OtherMatrix, SymmGroup>::col_proxy col_proxy;
 
         typedef typename SymmGroup::charge charge;
         typedef std::size_t size_t;

--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
@@ -107,7 +107,6 @@ struct contraction {
                 ProductBasis<SymmGroup> const & out_left_pb)
     {
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::index_type index_type;
-        typedef typename MPOTensor<OtherMatrix, SymmGroup>::row_proxy row_proxy;
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::col_proxy col_proxy;
 
         typedef typename SymmGroup::charge charge;


### PR DESCRIPTION
## Summary

`rbtm_kernel` only iterates over MPO rows (`row_proxy`) — symmetric to the `lbtm_kernel` fix in #61. `col_proxy` was declared but never referenced in this function. Flagged by `-Wunused-local-typedef`.

## Test plan

- [ ] Build succeeds without `-Wunused-local-typedef` warning on this line
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)