### PR TITLE
Remove unused 'charge' typedef in density_matrix_2 (contractions.h)

### DIFF
--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
@@ -964,8 +964,6 @@ struct contraction {
     density_matrix_2(MPSTensor<Matrix, SymmGroup> const & bra_tensor,
                      MPSTensor<Matrix, SymmGroup> const & ket_tensor)
     {
-        typedef typename SymmGroup::charge charge;
-        
         assert( bra_tensor.row_dim() == ket_tensor.row_dim() );
         assert( bra_tensor.col_dim() == ket_tensor.col_dim() );
         assert( bra_tensor.site_dim() == ket_tensor.site_dim() );

--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
@@ -186,7 +186,6 @@ struct contraction {
     {
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::index_type index_type;
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::row_proxy row_proxy;
-        typedef typename MPOTensor<OtherMatrix, SymmGroup>::col_proxy col_proxy;
 
         typedef typename SymmGroup::charge charge;
         typedef std::size_t size_t;

--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/contractions.h
@@ -107,7 +107,6 @@ struct contraction {
                 ProductBasis<SymmGroup> const & out_left_pb)
     {
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::index_type index_type;
-        typedef typename MPOTensor<OtherMatrix, SymmGroup>::row_proxy row_proxy;
         typedef typename MPOTensor<OtherMatrix, SymmGroup>::col_proxy col_proxy;
 
         typedef typename SymmGroup::charge charge;


### PR DESCRIPTION
## Summary

`density_matrix_2` declared `typedef typename SymmGroup::charge charge` but the function body uses `Index<SymmGroup>` and `block_matrix` directly without ever naming the charge type. Flagged by `-Wunused-local-typedef`.

## Test plan

- [ ] Build succeeds without `-Wunused-local-typedef` warning on this line
- [ ] Full test suite passes (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)