### PR TITLE
Remove unused typedef declarations in DMRG mp_tensors and optimize

### DIFF
--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/mpo_ops.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/mpo_ops.h
@@ -92,7 +92,6 @@ void follow_and_print_terms(MPO<Matrix, SymmGroup> const& mpo, int p, int b1, in
     }
     
     typedef typename MPOTensor<Matrix, SymmGroup>::row_proxy row_proxy;
-    typedef typename MPOTensor<Matrix, SymmGroup>::col_proxy col_proxy;
     row_proxy myrow = mpo[p+1].row(b2);
     for (typename row_proxy::const_iterator row_it = myrow.begin(); row_it != myrow.end(); ++row_it)
         follow_and_print_terms(mpo, p+1, b2, row_it.index(), ss.str(), scale);
@@ -147,7 +146,6 @@ template<class Matrix, class SymmGroup>
 MPO<Matrix, SymmGroup>
 square_mpo(MPO<Matrix, SymmGroup> const & mpo)
 {
-    typedef typename SymmGroup::charge charge;
     typedef typename MPOTensor<Matrix, SymmGroup>::row_proxy row_proxy;
     typedef typename MPOTensor<Matrix, SymmGroup>::index_type index_type;
     
@@ -202,9 +200,6 @@ template<class Matrix, class SymmGroup>
 MPO<Matrix, SymmGroup>
 zero_after(MPO<Matrix, SymmGroup> mpo, int p0)
 {
-    typedef typename MPOTensor<Matrix, SymmGroup>::CSRMatrix CSRMatrix;
-    typedef typename MPOTensor<Matrix, SymmGroup>::CSCMatrix CSCMatrix;
-
     maquis::cout << "Zeroing out MPO after site " << p0 << std::endl;
 
     for (int p = p0+1; p < mpo.size(); ++p) {

--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/mps_initializers.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/mps_initializers.h
@@ -352,14 +352,12 @@ public:
     {
         assert(coeff.size() == mps.length());
         if (phys_dims[0].size() != 1) throw std::runtime_error("coherent_mps_init only for TrivialGroup.");
-        
-        typedef typename SymmGroup::charge charge;
-        
+
         using std::exp; using std::sqrt; using std::pow;
         using boost::math::factorial;
-        
+
         size_t L = coeff.size();
-        
+
         Index<SymmGroup> trivial_i;
         trivial_i.insert(std::make_pair(SymmGroup::IdentityCharge, 1));
         
@@ -402,13 +400,11 @@ public:
         
         assert(coeff.size() == mps.length());
         if (phys_rho_dims[0].size() != 1) throw std::runtime_error("coherent_dm_mps_init only for TrivialGroup.");
-        
+
         std::vector<Index<SymmGroup> > phys_psi_dims(phys_rho_dims.size());
         for (int type=0; type<phys_rho_dims.size(); ++type)
             phys_psi_dims[type].insert( std::make_pair( SymmGroup::IdentityCharge, static_cast<size_t>(sqrt(double(phys_rho_dims[type][0].second))) ) );
-        
-        typedef typename SymmGroup::charge charge;
-        
+
         using std::exp; using std::sqrt; using std::pow;
         using boost::math::factorial;
         

--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/mps_sectors.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/mps_sectors.h
@@ -48,9 +48,7 @@ inline std::vector<Index<SymmGroup> > allowed_sectors(std::vector<int> const& si
     bool finitegroup = SymmGroup::finite;
 
     std::size_t L = site_type.size();
-    
-    typedef typename SymmGroup::subcharge subcharge;
-    
+
     std::vector<typename SymmGroup::charge> maximum_charges(phys_dims.size()), minimum_charges(phys_dims.size());
     for (int type=0; type<phys_dims.size(); ++type) {
         Index<SymmGroup> physc = phys_dims[type];

--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/state_mps.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/state_mps.h
@@ -37,8 +37,7 @@ MPS<Matrix, SymmGroup> state_mps(std::vector<boost::tuple<Charge, std::size_t> >
                                  std::vector<Index<SymmGroup> > const& phys_dims, std::vector<int> const& site_type)
 {
     typedef typename SymmGroup::charge charge;
-    typedef boost::tuple<charge, size_t> local_state;
-    
+
     MPS<Matrix, SymmGroup> mps(state.size());
     
     Index<SymmGroup> curr_i;

--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/super_mpo.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/super_mpo.h
@@ -209,7 +209,6 @@ MPS<Matrix, typename grouped_symmetry<InSymm>::type> mpo_to_smps_group(MPO<Matri
     typedef typename grouped_symmetry<InSymm>::type OutSymm;
     typedef typename InSymm::charge in_charge;
     typedef typename OutSymm::charge out_charge;
-    typedef boost::unordered_map<size_t,std::pair<out_charge,size_t> > bond_charge_map;
     typedef typename MPOTensor<Matrix, InSymm>::row_proxy row_proxy;
     
     MPS<Matrix, OutSymm> mps(mpo.size());

--- a/applications/dmrg/mps/framework/dmrg/mp_tensors/ts_ops.h
+++ b/applications/dmrg/mps/framework/dmrg/mp_tensors/ts_ops.h
@@ -49,7 +49,6 @@ MPOTensor<MPSMatrix, SymmGroup> make_twosite_mpo(MPOTensor<MPOMatrix, SymmGroup>
 
     typedef typename MPOTensor<MPOMatrix, SymmGroup>::index_type index_type;
     typedef typename MPOTensor<MPOMatrix, SymmGroup>::row_proxy row_proxy;
-    typedef typename MPOTensor<MPOMatrix, SymmGroup>::col_proxy col_proxy;
     typedef typename OPTable<MPSMatrix, SymmGroup>::tag_type tag_type;
     typedef typename OPTable<MPSMatrix, SymmGroup>::op_t op_t;
     typedef typename MPSMatrix::value_type value_type;

--- a/applications/dmrg/mps/framework/dmrg/optimize/ietl_lanczos_solver.h
+++ b/applications/dmrg/mps/framework/dmrg/optimize/ietl_lanczos_solver.h
@@ -139,9 +139,6 @@ solve_ietl_lanczos(SiteProblem<Matrix, SymmGroup> & sp,
     
     SingleSiteVS<Matrix, SymmGroup> vs(initial, std::vector<MPSTensor<Matrix, SymmGroup> >());
     
-    typedef ietl::vectorspace<Vector> Vecspace;
-    typedef boost::lagged_fibonacci607 Gen;
-    
     ietl::lanczos<SiteProblem<Matrix, SymmGroup>, SingleSiteVS<Matrix, SymmGroup> > lanczos(sp, vs);
     
     //            Vector test;


### PR DESCRIPTION
## Summary

Batch removal of unused local typedef declarations that generate `-Wunused-local-typedef` warnings across DMRG framework headers:

- **`mpo_ops.h`**: `col_proxy` in `follow_and_print_terms`, `charge` in `square_mpo`, `CSRMatrix`/`CSCMatrix` in `zero_after`
- **`mps_initializers.h`**: `charge` in `coherent_mps_init` and `coherent_dm_mps_init`
- **`mps_sectors.h`**: `subcharge` in `get_all_sector_sizes`
- **`state_mps.h`**: `local_state` in `state_mps`
- **`super_mpo.h`**: `bond_charge_map` in `mpo_to_smps_group`
- **`ts_ops.h`**: `col_proxy` in `mpo_kron`
- **`ietl_lanczos_solver.h`**: `Vecspace` and `Gen` in `solve_ietl_lanczos`

All removed typedefs were defined but never referenced in the function body. No functional changes.

## Test plan

- [ ] Build succeeds without `-Wunused-local-typedef` warnings for the affected files
- [ ] Existing DMRG tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)