### PR TITLE
Fix deprecated std::binary_function/bind2nd and unused typedef in numeric/matrix

### DIFF
--- a/src/alps/numeric/matrix/operators/op_assign_vector.hpp
+++ b/src/alps/numeric/matrix/operators/op_assign_vector.hpp
@@ -35,17 +35,6 @@
 
 namespace alps {
 namespace numeric {
-    namespace detail {
-            template <typename T, typename T2>
-            struct multiplies : public std::binary_function<T,T2,T>
-            {
-                inline T operator()(T t, T2 const& t2) const
-                {
-                    return t*t2;
-                }
-            };
-    } // end namespace detail
-
     namespace impl {
 #if defined(__clang_major__) && __clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ == 0) || defined(BOOST_MSVC)
 // Workaround for a compiler bug in clang 3.0 (and maybe earlier versions)
@@ -85,8 +74,7 @@ namespace numeric {
     template <typename Vector, typename T2>
     void multiplies_assign_impl(Vector& lhs, T2 lambda, tag::vector tag1, tag::scalar tag2, boost::mpl::false_)
     {
-        using detail::multiplies;
-        std::transform(lhs.begin(), lhs.end(), lhs.begin(), std::bind2nd(multiplies<typename Vector::value_type, T2>(), lambda));
+        std::transform(lhs.begin(), lhs.end(), lhs.begin(), [&lambda](typename Vector::value_type t) { return t * lambda; });
     }
 #endif // defined(__clang_major__) && __clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ == 0)
 

--- a/src/alps/numeric/matrix/ublas_sparse_functions.hpp
+++ b/src/alps/numeric/matrix/ublas_sparse_functions.hpp
@@ -48,7 +48,6 @@ typename multiply_return_type_helper<matrix<T>,Vector>::type multiply(::boost::n
     using ::boost::numeric::ublas::map_std;
     BOOST_STATIC_ASSERT(( boost::is_same<A, map_std<std::size_t, map_std<std::size_t, T> > >::value ));
     BOOST_STATIC_ASSERT(( boost::is_same<L, ::boost::numeric::ublas::row_major>::value ));
-    typedef A array_type;
     typedef typename map_std<std::size_t, map_std<std::size_t, T> >::const_iterator const_iterator1;
     typedef typename map_std<std::size_t, T>::const_iterator                        const_iterator2;
 


### PR DESCRIPTION
## Summary

- **`src/alps/numeric/matrix/operators/op_assign_vector.hpp`**: Removes the `detail::multiplies` functor that inherited from the deprecated (C++11) and removed (C++17) `std::binary_function`, and replaces the `std::bind2nd` call in `multiplies_assign_impl` with an equivalent lambda. Fixes 6 `-Wdeprecated-declarations` warnings.
- **`src/alps/numeric/matrix/ublas_sparse_functions.hpp`**: Removes unused `typedef A array_type` in `multiply`. Fixes 1 `-Wunused-local-typedef` warning.

## Test plan

- [ ] Build succeeds without deprecation warnings for these files
- [ ] Existing numeric/matrix tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)