### PR TITLE
Fix warnings in applications/mc/spins

### DIFF
--- a/applications/mc/spins/abstract_fitter.C
+++ b/applications/mc/spins/abstract_fitter.C
@@ -1148,9 +1148,9 @@ void AbstractFitter::print_results(const std::string filename) const
   char time_measure[256];
   boost::posix_time::time_duration time_used;
   time_used = boost::posix_time::second_clock::local_time() - start_time;
-  snprintf(time_measure,sizeof(time_measure), "\nRan %i hours, %i minutes %i seconds.",
-               time_used.hours(), time_used.minutes(),
-               time_used.seconds());
+  snprintf(time_measure,sizeof(time_measure), "\nRan %ld hours, %ld minutes %ld seconds.",
+               static_cast<long>(time_used.hours()), static_cast<long>(time_used.minutes()),
+               static_cast<long>(time_used.seconds()));
 
   mean_stream << "\n" << time_measure << std::endl;
   error_stream << "\n" << time_measure << std::endl;

--- a/applications/mc/spins/base_incr_fitter.C
+++ b/applications/mc/spins/base_incr_fitter.C
@@ -178,7 +178,7 @@ void BaseIncrFitter::save_choose(int expected, int min, int max, int nbiggest)
     exp_results.push_back(all_exp_res[ranking[i]]);
     remaining_curv_sum -= curvature[i];
   }
-  delete ranking;
+  delete[] ranking;
   // choose the remaining elements by adding elements
   if (min > nbiggest)
     add_exp_results(expected-nbiggest, min-nbiggest, max-nbiggest);

--- a/applications/mc/spins/spinsim.h
+++ b/applications/mc/spins/spinsim.h
@@ -164,7 +164,6 @@ void SpinSim<M, MIdMatrix<double,M::dim> >::load(alps::IDump& dump)
 template <class M, class MAT> 
 update_info_type SpinSim<M,MAT>::do_update()
 {
-    typedef AbstractSpinSim<MAT> parent;
     if (this->general_case_)
       local_update_self(this->graph(),spins_, this->beta_,this->random_01,
           this->couplings_,this->selfinteraction_,this->spinfactor_,this->g_,this->h_);
@@ -180,7 +179,6 @@ update_info_type SpinSim<M,MAT>::do_update()
 template<class M>
 update_info_type SpinSim<M,MIdMatrix<double,M::dim> >::do_update()
 {
-  typedef AbstractSpinSim<MIdMatrix<double,M::dim> > parent;
   if (this->cluster_updates_)
     if (this->general_case_)
       return cluster_update(this->graph(),spins_, this->beta_,


### PR DESCRIPTION
## Summary

- **`abstract_fitter.C`**: Fix `-Wformat` warnings — `snprintf` used `%i` for `hour_type`/`min_type`/`sec_type` arguments which are `long long`. Changed to `%ld` with `static_cast<long>`.
- **`base_incr_fitter.C`**: Fix `-Wmismatched-new-delete` — `ranking` is allocated with `new int[]` but freed with `delete` instead of `delete[]`.
- **`spinsim.h`**: Remove two unused `typedef ... parent` declarations that trigger `-Wunused-local-typedef`.

## Test plan

- [ ] Build succeeds without warnings for the affected files
- [ ] Existing mc/spins tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)