### PR TITLE
Fix warnings in applications/qmc

### DIFF
--- a/applications/qmc/checksign/checksign.C
+++ b/applications/qmc/checksign/checksign.C
@@ -72,14 +72,12 @@ void check_xmlfile(const std::string& name)
   std::ifstream xml(name.c_str());
   alps::XMLTag tag=alps::parse_tag(xml,true);
   if (tag.name=="JOB") {
-    int j=0;
     tag=alps::parse_tag(xml,true);
     while (tag.name!="/JOB") {
       if (tag.name=="TASK") {
         tag=alps::parse_tag(xml,true);
         while (tag.name !="/TASK") {
           if (tag.name=="INPUT") {
-            ++j;         
             check_xmlfile(tag.attributes["file"]);
           }
           else

--- a/applications/qmc/worms/Wdostep.C
+++ b/applications/qmc/worms/Wdostep.C
@@ -86,10 +86,10 @@ if (canonical) {
   if (static_cast<int>(parms["NUMBER_OF_PARTICLES"])==get_particle_number()) 
     measure();
 }
-else 
+else
   measure();
 
-  steps++;
+steps++;
 #ifdef TIMINGS
   tt += dclock();
   std::cerr << "Meas time: " << tt << " seconds\n";


### PR DESCRIPTION
## Summary

- **checksign/checksign.C**: Remove unused variable j — it counted INPUT tags but the count was never used. Fixes -Wunused-but-set-variable.
- **worms/Wdostep.C**: Fix misleading indentation on steps++ — dedented to make clear it executes unconditionally after the if/else block. Fixes -Wmisleading-indentation.

## Test plan

- [ ] Build succeeds without warnings for the affected files
- [ ] Existing qmc tests pass

Generated with Claude Code