### PR TITLE
Fix warnings in bundled src/ietl headers

### DIFF
--- a/src/ietl/bicgstabl.h
+++ b/src/ietl/bicgstabl.h
@@ -65,7 +65,6 @@ namespace ietl {
         {
             typedef VECTOR vector_t;
             typedef SCALAR scalar_t;
-            typedef typename real_type<scalar_t>::type real_t;
             typedef typename number_traits<SCALAR>::magnitude_type magnitude_t;
             typedef std::vector<vector_t> vector_set_t;
             typedef ublas::matrix<scalar_t, ublas::row_major> matrix_t;

--- a/src/ietl/jacobi.h
+++ b/src/ietl/jacobi.h
@@ -483,7 +483,7 @@ namespace ietl
         fortran_int_t lwork=8*n;
         fortran_int_t info;
 
-        double vl, vu;
+        double vl = 0., vu = 0.;
 
         double *w = new double[n];
         double *z = new double[n];
@@ -523,7 +523,7 @@ namespace ietl
         fortran_int_t ldz=n;
         fortran_int_t lwork=8*n;
         fortran_int_t info; 
-        double vl, vu;
+        double vl = 0., vu = 0.;
 
         double * w = new double[n];
         std::complex<double> * z = new std::complex<double>[n];


### PR DESCRIPTION
## Summary

- **bicgstabl.h**: remove unused typedef 'real_t' (-Wunused-local-typedef)
- **jacobi.h**: initialize vl/vu to 0.0 in both get_extremal_eigenvalue overloads (real and complex); these are passed to LAPACK DSYEVX/ZHEEVX with range='I' so are never read by LAPACK, but were uninitialized (-Wuninitialized-const-pointer)

## Test plan

- [ ] Build succeeds without warnings for the affected files

Generated with Claude Code