### PR TITLE
Fix misleading indentation in alps/scheduler

### DIFF
--- a/src/alps/scheduler/diag.hpp
+++ b/src/alps/scheduler/diag.hpp
@@ -132,7 +132,7 @@ void DiagTask<T,G>::save(hdf5::archive & ar) const {
     for (unsigned j=0;j<this->quantumnumbervalues_[i].size();++j)
       ar << make_pvp(sectorpath + "/quantumnumbers/" + this->quantumnumbervalues_[i][j].first,
                      this->quantumnumbervalues_[i][j].second);
-      ar << make_pvp(sectorpath + "/energies",eigenvalues_[i]);
+    ar << make_pvp(sectorpath + "/energies",eigenvalues_[i]);
     if (calc_averages() || this->parms.value_or_default("MEASURE_ENERGY",true))
       ar << make_pvp(sectorpath,measurements_[i]);
   }

--- a/src/alps/scheduler/mpp_scheduler.C
+++ b/src/alps/scheduler/mpp_scheduler.C
@@ -177,9 +177,9 @@ void MPPScheduler::assign_processes(ProcessList& free)
       if(found>=0) {
         if(first_new<0)
           first_new=found;
-          more_processes[found]=min_cpus*active[found].cpus;
-          free_processes-=min_cpus*active[found].cpus;
-        }
+        more_processes[found]=min_cpus*active[found].cpus;
+        free_processes-=min_cpus*active[found].cpus;
+      }
       } while ((found >= 0) && free_processes>=min_cpus);
 
       // don't use local process if no new tasks are started


### PR DESCRIPTION
## Summary

- **diag.hpp**: Dedent the energies archive write to align with the outer for loop body — it was indented to match the inner for loop body, making it look conditional on the inner loop (-Wmisleading-indentation).
- **mpp_scheduler.C**: Dedent the more_processes/free_processes assignments to make clear they execute unconditionally within if(found>=0), not only when if(first_new<0) is true (-Wmisleading-indentation).

## Test plan

- [ ] Build succeeds without misleading-indentation warnings for these files

Generated with Claude Code