### PR TITLE
Fix -Wnontrivial-memcall: replace memcpy with std::copy in convert2vector

### DIFF
--- a/src/alps/python/numpy_array.hpp
+++ b/src/alps/python/numpy_array.hpp
@@ -123,7 +123,7 @@ namespace alps {
         T * data = (T *) PyArray_DATA(ptr);
 
         std::vector<T> vec(vec_size);
-        memcpy(&vec.front(), data, PyArray_ITEMSIZE(ptr) * vec_size);
+        std::copy(data, data + vec_size, vec.begin());
         return vec;
       }
 

--- a/src/alps/python/pyalea.cpp
+++ b/src/alps/python/pyalea.cpp
@@ -397,7 +397,19 @@ ALPS_MCANALYZE_EXPORT_TIMESERIES_FUNCTION_SCALAR_ONLY(running_mean, alps::alea::
 ALPS_MCANALYZE_EXPORT_TIMESERIES_FUNCTION_SCALAR_ONLY(reverse_running_mean, alps::alea::reverse_running_mean, reverse_running_mean_docstring)
 
 ALPS_MCANALYZE_EXPORT_MCTIMESERIES_CLASSES(double, MCScalarTimeseries)
-ALPS_MCANALYZE_EXPORT_MCTIMESERIES_CLASSES(std::vector<double>, MCVectorTimeseries)
+class_<alps::alea::mctimeseries< std::vector<double> > >( "MCVectorTimeseries" , mctimeseries_docstring)
+    .def(init<alps::alea::mcdata< std::vector<double> > >(mcdata_constructor_docstring))
+    .def("timeseries", &alps::alea::mctimeseries< std::vector<double> >::timeseries_python, mctimeseries_timeseries_docstring)
+    .add_property("size", &alps::alea::mctimeseries< std::vector<double> >::size, size_docstring)
+    .def("__repr__", &alps::alea::print_to_python<alps::alea::mctimeseries< std::vector<double> > >)
+  ;
+
+  class_<alps::alea::mctimeseries_view< std::vector<double> > >( "MCVectorTimeseriesView", mctimeseries_view_docstring, init< alps::alea::mctimeseries< std::vector<double> > >(mctimeseries_constructor_docstring))
+    .def(init< alps::alea::mctimeseries_view< std::vector<double> > >(mctimeseries_view_constructor_docstring))
+    .def("timeseries", &alps::alea::mctimeseries_view< std::vector<double> >::timeseries_python, numpy_constructor_docstring)
+    .add_property("size", &alps::alea::mctimeseries_view< std::vector<double> >::size, size_docstring)
+    .def("__repr__", &alps::alea::print_to_python<alps::alea::mctimeseries_view< std::vector<double> > >)
+  ;
 //ALPS_MCANALYZE_EXPORT_MCTIMESERIES_CLASSES(alps::alea::value_with_error<double>, MCScalarTimeseriesWithError)
 
 


### PR DESCRIPTION
## Summary

- `src/alps/python/numpy_array.hpp`: Replace `memcpy` with `std::copy` in `convert2vector<T>`. Calling `memcpy` on `std::vector<T>` elements is undefined behavior when `T` is not trivially copyable (clang `-Wnontrivial-memcall`).
- `src/alps/python/pyalea.cpp`: Expand `ALPS_MCANALYZE_EXPORT_MCTIMESERIES_CLASSES` inline for `MCVectorTimeseries` to omit the `init<boost::python::object>` numpy constructor. That constructor calls `convert2vector<std::vector<double>>` which is the UB instantiation. The numpy-from-array path for vector timeseries was never tested (test lines are commented out).

## Test plan

- [ ] Build the Python bindings (`pyalps` module) and confirm it compiles without `-Wnontrivial-memcall`
- [ ] Verify `MCScalarTimeseries` still accepts numpy array construction (unchanged)
- [ ] Verify `MCVectorTimeseries` still accepts `mcdata<std::vector<double>>` construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)