### PR TITLE
Fix -Wmisleading-indentation in hdf5_vecveccplx test

### DIFF
--- a/test/hdf5/hdf5_vecveccplx.cpp
+++ b/test/hdf5/hdf5_vecveccplx.cpp
@@ -41,12 +41,12 @@ int main()
 {
     if (boost::filesystem::exists(boost::filesystem::path("vvcplx.h5")))
         boost::filesystem::remove(boost::filesystem::path("vvcplx.h5"));
-	{
+    {
       vector< vector< complex<double> > > v;
       for( int i = 0; i < 3; ++i )
         v.push_back(vector< complex<double> >(i+1, complex<double>(i,2*i)));
       alps::hdf5::archive ar("vvcplx.h5",alps::hdf5::archive::WRITE);
       ar << alps::make_pvp("v",v);
-	}
+    }
     boost::filesystem::remove(boost::filesystem::path("vvcplx.h5"));
 }


### PR DESCRIPTION
## Summary

- `test/hdf5/hdf5_vecveccplx.cpp`: The scoping block braces (`{`/`}`) used tab characters for indentation while the surrounding code uses spaces. Clang interprets the tab-indented `{` as potentially being the body of the preceding `if` statement (which already ended with a semicolon), triggering `-Wmisleading-indentation`. Replaced tabs with 4 spaces to match the rest of `main()`.

## Test plan

- [ ] Build succeeds without `-Wmisleading-indentation`
- [ ] `ctest -R hdf5_vecveccplx` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)