### PR TITLE
Fix unused-variable and misleading-indentation warnings

### DIFF
--- a/applications/dmrg/dmrg/dmtk/system.h
+++ b/applications/dmrg/dmrg/dmtk/system.h
@@ -1968,10 +1968,9 @@ System<T>::truncate(int position, int new_size)
     for(biter = rho.begin(); biter != rho.end(); biter++){
       SubMatrix<T> &block(*biter);
       bool found = false;
-      bool first = false;
       for(ib = 0; ib < bsize; ib++){
         SubMatrix<T> *_block = bvector(bidx(ib));
-        if(_block == &block) { found = true; first = (ib == 0); break; }
+        if(_block == &block) { found = true; break; }
       }
       if(!found) continue; 
 
@@ -3158,7 +3157,6 @@ System<T>::measure(const VectorState<T> *v)
       res = T(0);
       for(int ib = 0; ib < 4; ib++) aux_term[ib].clear();
       bool found = true;
-      int bmask = 0;
       for(int i = 0; i < t.size(); i++){
         BasicOp<T> top = t[i];
         if(block(top.site()) == BLOCK_NONE){
@@ -3168,7 +3166,6 @@ System<T>::measure(const VectorState<T> *v)
         for(int ib = 1; ib <= 4; ib++){
           if(block(top.site()) == (size_t)ib){
             aux_term[ib-1] *= top;
-            bmask |= mask((size_t)ib);
           }
         }
       } 

--- a/applications/dmrg/mps/framework/dmrg/models/generate_mpo/utils.hpp
+++ b/applications/dmrg/mps/framework/dmrg/models/generate_mpo/utils.hpp
@@ -105,7 +105,7 @@ namespace generate_mpo
         os << "operators:";
         for (int i=0; i<op.operators.size(); ++i)
             os << " {"  << op.operators[i].first << "," << op.operators[i].second << "}";
-            os << std::endl;
+        os << std::endl;
         return os;
     }
     

--- a/applications/qmc/checksign/checksign.C
+++ b/applications/qmc/checksign/checksign.C
@@ -72,14 +72,12 @@ void check_xmlfile(const std::string& name)
   std::ifstream xml(name.c_str());
   alps::XMLTag tag=alps::parse_tag(xml,true);
   if (tag.name=="JOB") {
-    int j=0;
     tag=alps::parse_tag(xml,true);
     while (tag.name!="/JOB") {
       if (tag.name=="TASK") {
         tag=alps::parse_tag(xml,true);
         while (tag.name !="/TASK") {
           if (tag.name=="INPUT") {
-            ++j;         
             check_xmlfile(tag.attributes["file"]);
           }
           else

--- a/applications/qmc/worms/Wdostep.C
+++ b/applications/qmc/worms/Wdostep.C
@@ -86,10 +86,10 @@ if (canonical) {
   if (static_cast<int>(parms["NUMBER_OF_PARTICLES"])==get_particle_number()) 
     measure();
 }
-else 
+else
   measure();
 
-  steps++;
+steps++;
 #ifdef TIMINGS
   tt += dclock();
   std::cerr << "Meas time: " << tt << " seconds\n";

--- a/tool/maxent_parms.cpp
+++ b/tool/maxent_parms.cpp
@@ -43,9 +43,9 @@ T_(p["T"]|1./static_cast<double>(p["BETA"])),
 ndat_(p["NDAT"]), nfreq_(p["NFREQ"]),
 y_(ndat_),sigma_(ndat_), x_(ndat_),K_(),t_array_(nfreq_+1)
 {
-  if (ndat_<4) 
+  if (ndat_<4)
     boost::throw_exception(std::invalid_argument("NDAT too small"));
-    std::string p_f_grid = p["FREQUENCY_GRID"]|"";
+  std::string p_f_grid = p["FREQUENCY_GRID"]|"";
   if (p_f_grid=="Lorentzian") {
     double cut = p["CUT"]|0.01;
     std::vector<double> temp(nfreq_+1);


### PR DESCRIPTION
## Summary

- Remove dead variables `first` (set but never read) in `dmtk/system.h:1971`
- Remove dead variable `bmask` (accumulated but never consumed) in `dmtk/system.h:3161`
- Remove unused counter `j` in `checksign.C:75`
- Fix misleading indentation in `generate_mpo/utils.hpp:108` (os endl was outside the for loop but aligned with its body)
- Fix misleading indentation in `Wdostep.C:92` (steps++ was outside the if/else but had extra leading whitespace)
- Fix misleading indentation in `maxent_parms.cpp:48` (p_f_grid declaration was outside the if block but indented as if inside)

These are the remaining ALPS-source warnings from a clean C++11 build, excluding the DMRG unused-typedef batch covered by PR #65.

## Test plan

- [x] Clean C++11 build produces no new warnings
- [x] All 152 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)