### PR TITLE
Fix parallel test output collision in run_test.cmake

### DIFF
--- a/config/run_test.cmake
+++ b/config/run_test.cmake
@@ -36,7 +36,7 @@ if(input_path)
     COMMAND ${cmd_path}
     RESULT_VARIABLE not_successful
     INPUT_FILE ${input_path}
-    OUTPUT_FILE ${cmd}_output
+    OUTPUT_FILE ${cmd}_${input}_output
     ERROR_VARIABLE err
     TIMEOUT 600
   )
@@ -44,7 +44,7 @@ else(input_path)
   execute_process(
     COMMAND ${cmd_path}
     RESULT_VARIABLE not_successful
-    OUTPUT_FILE ${cmd}_output
+    OUTPUT_FILE ${cmd}_${input}_output
     ERROR_VARIABLE err
     TIMEOUT 600
   )
@@ -56,10 +56,10 @@ endif(not_successful)
 
 if(output_path)
   if(WIN32)
-    configure_file(${cmd}_output ${cmd}_output NEWLINE_STYLE LF)
+    configure_file(${cmd}_${input}_output ${cmd}_${input}_output NEWLINE_STYLE LF)
   endif(WIN32)
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E compare_files ${output_path} ${cmd}_output
+    COMMAND ${CMAKE_COMMAND} -E compare_files ${output_path} ${cmd}_${input}_output
     RESULT_VARIABLE not_successful
     OUTPUT_VARIABLE out
     ERROR_VARIABLE err
@@ -70,4 +70,4 @@ if(output_path)
   endif(not_successful)
 endif(output_path)
 
-file(REMOVE ${cmd}_output)
+file(REMOVE ${cmd}_${input}_output)


### PR DESCRIPTION
## Summary

When CTest runs tests in parallel, all tests sharing the same executable name write their captured stdout to the same file (`${cmd}_output`) in the shared working directory. This caused a three-way race on `simplemc_output` between `simplemc_ising`, `simplemc_xy`, and `simplemc_heisenberg`, producing intermittent failures under `ctest -j`.

The fix uses `${cmd}_${input}_output` as the temp filename so every test variant gets a unique file. The `input` variable is always set (the macro defaults it to the command name in the 1-argument form), so this is safe for all existing tests.

## Test plan

- [x] `ctest --parallel 8` passes all 152 tests with no failures (previously 3 simplemc tests failed intermittently)
- [x] `ctest -j1` still passes all 152 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)