### PR TITLE
Add ALPS_USE_SYSTEM_BOOST for Spack/system-installed Boost

### DIFF
--- a/config/FindBoostForALPS.cmake
+++ b/config/FindBoostForALPS.cmake
@@ -31,8 +31,11 @@ if(ALPS_USE_SYSTEM_BOOST)
   # System Boost path
   # -----------------------------------------------------------------------
 
+  # Note: boost::system is header-only since Boost 1.69 and has no library
+  # file to link against — omitting it from the component list avoids a
+  # FindBoost failure when ALPS_USE_SYSTEM_BOOST=ON with Boost >= 1.69.
   set(_alps_boost_components
-      filesystem serialization system program_options regex
+      filesystem serialization program_options regex
       thread date_time chrono timer iostreams unit_test_framework)
 
   if(ALPS_ENABLE_MPI)

--- a/config/FindBoostForALPS.cmake
+++ b/config/FindBoostForALPS.cmake
@@ -4,22 +4,108 @@
 
 #  Copyright Ryo IGARASHI 2010, 2011, 2013.
 #   Permission is hereby granted, free of charge, to any person obtaining
-#   a copy of this software and associated documentation files (the “Software”),
+#   a copy of this software and associated documentation files (the "Software"),
 #   to deal in the Software without restriction, including without limitation
 #   the rights to use, copy, modify, merge, publish, distribute, sublicense,
 #   and/or sell copies of the Software, and to permit persons to whom the
 #   Software is furnished to do so, subject to the following conditions:
-#  
+#
 #   The above copyright notice and this permission notice shall be included
 #   in all copies or substantial portions of the Software.
-#  
-#   THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 #   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 #   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 #   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 #   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #   DEALINGS IN THE SOFTWARE.
+
+# ALPS_USE_SYSTEM_BOOST: when ON, use a system-installed precompiled Boost
+# instead of building from source.  The source build remains the default.
+option(ALPS_USE_SYSTEM_BOOST "Use system-installed Boost instead of building from source" OFF)
+
+if(ALPS_USE_SYSTEM_BOOST)
+
+  # -----------------------------------------------------------------------
+  # System Boost path
+  # -----------------------------------------------------------------------
+
+  set(_alps_boost_components
+      filesystem serialization system program_options regex
+      thread date_time chrono timer iostreams unit_test_framework)
+
+  if(ALPS_ENABLE_MPI)
+    list(APPEND _alps_boost_components mpi)
+  endif()
+
+  # Find the non-Python components first (all required).
+  find_package(Boost REQUIRED COMPONENTS ${_alps_boost_components})
+
+  # Python component: library naming varies by Boost/distro version.
+  # Try python<major><minor> (e.g. python311), then python3, then python.
+  if(ALPS_HAVE_PYTHON)
+    set(_alps_python_component "")
+    foreach(_pycomp "python${PYVER}" "python3" "python")
+      find_package(Boost QUIET COMPONENTS ${_pycomp})
+      if(Boost_${_pycomp}_FOUND)
+        set(_alps_python_component ${_pycomp})
+        break()
+      endif()
+    endforeach()
+
+    if(_alps_python_component)
+      message(STATUS "Found system Boost.Python component: ${_alps_python_component}")
+      # Merge the python library into Boost_LIBRARIES if not already there.
+      list(APPEND Boost_LIBRARIES Boost::${_alps_python_component})
+    else()
+      message(WARNING
+        "System Boost.Python library not found (tried python${PYVER}, python3, python). "
+        "Python bindings will be disabled.")
+      set(ALPS_HAVE_PYTHON OFF)
+      set(BUILD_BOOST_PYTHON OFF)
+    endif()
+  endif()
+
+  # Set ALPS_HAVE_BOOST_NUMPY for Boost >= 1.63 (when boost::python::numpy
+  # was introduced).
+  if(Boost_VERSION_STRING VERSION_GREATER_EQUAL "1.63.0")
+    set(ALPS_HAVE_BOOST_NUMPY ON)
+  endif()
+
+  # Scenario 3: system Boost 1.63-1.86 + NumPy >= 2.0.
+  # boost::python::numpy in these versions uses deprecated NumPy C API
+  # removed in NumPy 2.0.  Fall back to boost::python::numeric::array,
+  # which uses only the stable NumPy C API.
+  if(ALPS_HAVE_BOOST_NUMPY AND ALPS_HAVE_PYTHON)
+    EXEC_PYTHON_SCRIPT("import numpy; print(numpy.__version__)" _alps_numpy_ver)
+    message(STATUS "NumPy version: ${_alps_numpy_ver}")
+    if(_alps_numpy_ver VERSION_GREATER_EQUAL "2.0.0" AND
+       Boost_VERSION_STRING VERSION_LESS "1.87.0")
+      message(WARNING
+        "System Boost ${Boost_VERSION_STRING} does not support NumPy >= 2.0 "
+        "(requires Boost >= 1.87). "
+        "Falling back to boost::python::numeric::array. "
+        "Upgrade system Boost to >= 1.87 to silence this warning.")
+      set(ALPS_HAVE_BOOST_NUMPY OFF)
+    endif()
+  endif()
+
+  # Align Boost_INCLUDE_DIR (singular) used elsewhere in the build.
+  set(Boost_INCLUDE_DIR ${Boost_INCLUDE_DIRS})
+
+  message(STATUS "Using system Boost ${Boost_VERSION_STRING}")
+  message(STATUS "  includes:           ${Boost_INCLUDE_DIRS}")
+  message(STATUS "  libraries:          ${Boost_LIBRARIES}")
+  message(STATUS "  ALPS_HAVE_BOOST_NUMPY: ${ALPS_HAVE_BOOST_NUMPY}")
+
+  return()
+
+endif() # ALPS_USE_SYSTEM_BOOST
+
+# -----------------------------------------------------------------------
+# Source-build path (original behaviour)
+# -----------------------------------------------------------------------
 
 # Since Boost_ROOT_DIR is used for setting Boost source directory,
 # we use precompiled Boost libraries only when Boost_ROOT_DIR is not set.

--- a/config/FindBoostForALPS.cmake
+++ b/config/FindBoostForALPS.cmake
@@ -39,29 +39,49 @@ if(ALPS_USE_SYSTEM_BOOST)
     list(APPEND _alps_boost_components mpi)
   endif()
 
+  # Force CMake module mode (FindBoost.cmake) so component names like
+  # unit_test_framework work regardless of whether the system Boost ships
+  # a BoostConfig.cmake (config mode).  Config mode uses different component
+  # names and often conflicts with BOOST_ROOT overrides.
+  set(Boost_NO_BOOST_CMAKE TRUE)
+  # CMP0167 (CMake 3.30+) warns that the FindBoost module is deprecated in
+  # favour of Boost's own config file.  We intentionally use module mode here,
+  # so acknowledge the policy to suppress the warning.
+  if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 OLD)
+  endif()
+
   # Find the non-Python components first (all required).
   find_package(Boost REQUIRED COMPONENTS ${_alps_boost_components})
+  # Save Boost_LIBRARIES now — a second find_package(Boost) call below
+  # (for the Python component) would overwrite this variable.
+  set(_alps_boost_libraries_saved ${Boost_LIBRARIES})
 
   # Python component: library naming varies by Boost/distro version.
   # Try python<major><minor> (e.g. python311), then python3, then python.
   if(ALPS_HAVE_PYTHON)
     set(_alps_python_component "")
+    set(_alps_python_library "")
     foreach(_pycomp "python${PYVER}" "python3" "python")
       find_package(Boost QUIET COMPONENTS ${_pycomp})
       if(Boost_${_pycomp}_FOUND)
+        # Capture Boost_LIBRARIES right here: after a single-component
+        # find_package it contains exactly that one library path.
+        set(_alps_python_library ${Boost_LIBRARIES})
         set(_alps_python_component ${_pycomp})
         break()
       endif()
     endforeach()
 
+    # Restore the full library list (overwritten by the python find_package).
     if(_alps_python_component)
       message(STATUS "Found system Boost.Python component: ${_alps_python_component}")
-      # Merge the python library into Boost_LIBRARIES if not already there.
-      list(APPEND Boost_LIBRARIES Boost::${_alps_python_component})
+      set(Boost_LIBRARIES ${_alps_boost_libraries_saved} ${_alps_python_library})
     else()
       message(WARNING
         "System Boost.Python library not found (tried python${PYVER}, python3, python). "
         "Python bindings will be disabled.")
+      set(Boost_LIBRARIES ${_alps_boost_libraries_saved})
       set(ALPS_HAVE_PYTHON OFF)
       set(BUILD_BOOST_PYTHON OFF)
     endif()
@@ -74,6 +94,7 @@ if(ALPS_USE_SYSTEM_BOOST)
   endif()
 
   # Scenario 3: system Boost 1.63-1.86 + NumPy >= 2.0.
+  # (evaluated below; set the flag early so the numpy lib search is guarded by it)
   # boost::python::numpy in these versions uses deprecated NumPy C API
   # removed in NumPy 2.0.  Fall back to boost::python::numeric::array,
   # which uses only the stable NumPy C API.
@@ -91,8 +112,41 @@ if(ALPS_USE_SYSTEM_BOOST)
     endif()
   endif()
 
+  # Boost.NumPy library: only link when ALPS_HAVE_BOOST_NUMPY is still ON
+  # after the scenario-3 check above.  Library naming mirrors python: try
+  # numpy<major><minor>, numpy3, numpy.
+  if(ALPS_HAVE_BOOST_NUMPY AND ALPS_HAVE_PYTHON)
+    set(_alps_boost_libs_before_numpy ${Boost_LIBRARIES})
+    set(_alps_numpy_lib_found "")
+    foreach(_npcomp "numpy${PYVER}" "numpy3" "numpy")
+      find_package(Boost QUIET COMPONENTS ${_npcomp})
+      if(Boost_${_npcomp}_FOUND)
+        message(STATUS "Found system Boost.NumPy component: ${_npcomp}")
+        # Boost_LIBRARIES is now just the numpy lib — capture and restore.
+        set(_alps_numpy_library ${Boost_LIBRARIES})
+        set(Boost_LIBRARIES ${_alps_boost_libs_before_numpy} ${_alps_numpy_library})
+        set(_alps_numpy_lib_found TRUE)
+        break()
+      endif()
+    endforeach()
+    if(NOT _alps_numpy_lib_found)
+      message(WARNING
+        "System Boost.NumPy library not found (tried numpy${PYVER}, numpy3, numpy). "
+        "Falling back to boost::python::numeric::array.")
+      set(Boost_LIBRARIES ${_alps_boost_libs_before_numpy})
+      set(ALPS_HAVE_BOOST_NUMPY OFF)
+    endif()
+  endif()
+
   # Align Boost_INCLUDE_DIR (singular) used elsewhere in the build.
   set(Boost_INCLUDE_DIR ${Boost_INCLUDE_DIRS})
+
+  # Add the Boost lib directory to the linker search path so that @rpath
+  # transitive dependencies of Boost dylibs (e.g. libboost_graph,
+  # libboost_container) are found at link time on macOS.
+  if(Boost_LIBRARY_DIRS)
+    link_directories(${Boost_LIBRARY_DIRS})
+  endif()
 
   message(STATUS "Using system Boost ${Boost_VERSION_STRING}")
   message(STATUS "  includes:           ${Boost_INCLUDE_DIRS}")

--- a/config/FindBoostForALPS.cmake
+++ b/config/FindBoostForALPS.cmake
@@ -31,9 +31,6 @@ if(ALPS_USE_SYSTEM_BOOST)
   # System Boost path
   # -----------------------------------------------------------------------
 
-  # Note: boost::system is header-only since Boost 1.69 and has no library
-  # file to link against — omitting it from the component list avoids a
-  # FindBoost failure when ALPS_USE_SYSTEM_BOOST=ON with Boost >= 1.69.
   set(_alps_boost_components
       filesystem serialization program_options regex
       thread date_time chrono timer iostreams unit_test_framework)
@@ -55,7 +52,21 @@ if(ALPS_USE_SYSTEM_BOOST)
   endif()
 
   # Find the non-Python components first (all required).
+  # Note: boost::system is intentionally absent — it became header-only in
+  # Boost 1.69 (no library file to link).  Boost < 1.69 is not supported
+  # in this mode; the version check below enforces that.
   find_package(Boost REQUIRED COMPONENTS ${_alps_boost_components})
+
+  # Enforce the minimum: for Boost < 1.69 boost::system is a compiled
+  # library required by filesystem, and omitting it from the component list
+  # would produce a mis-linked binary.
+  if(Boost_VERSION_STRING VERSION_LESS "1.69.0")
+    message(FATAL_ERROR
+      "ALPS_USE_SYSTEM_BOOST requires Boost >= 1.69 "
+      "(found ${Boost_VERSION_STRING}). "
+      "Upgrade the system Boost installation or disable ALPS_USE_SYSTEM_BOOST.")
+  endif()
+
   # Save Boost_LIBRARIES now — a second find_package(Boost) call below
   # (for the Python component) would overwrite this variable.
   set(_alps_boost_libraries_saved ${Boost_LIBRARIES})

--- a/config/FindBoostSrc.cmake
+++ b/config/FindBoostSrc.cmake
@@ -114,7 +114,12 @@ if(BUILD_BOOST_PYTHON)
   EXEC_PYTHON_SCRIPT ("import numpy; print(numpy.__version__)" numpy_ver)
   MESSAGE(STATUS "numpy version ${numpy_ver}" )
   if(${numpy_ver} VERSION_GREATER_EQUAL "2.0.0" AND "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}" VERSION_LESS "1.87.0" )
-    message(FATAL_ERROR "NumPy version >=2.0 requres Boost version >=1.87.0, you have Boost version ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}.")
+    message(WARNING
+      "Boost ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION} "
+      "does not support NumPy >= 2.0 (requires Boost >= 1.87). "
+      "Falling back to boost::python::numeric::array. "
+      "Upgrade to Boost >= 1.87 to silence this warning.")
+    set(ALPS_HAVE_BOOST_NUMPY OFF)
   endif()
 endif()
 

--- a/src/boost/CMakeLists.txt
+++ b/src/boost/CMakeLists.txt
@@ -189,12 +189,12 @@ if(BUILD_BOOST_PYTHON)
       object/inheritance.cpp object/iterator.cpp object/life_support.cpp
       object/pickle_support.cpp object/stl_iterator.cpp
   )
-  if(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION GREATER 62)
+  if(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION GREATER 62 AND ALPS_HAVE_BOOST_NUMPY)
     set(SOURCES ${SOURCES}
       numpy/dtype.cpp numpy/matrix.cpp numpy/ndarray.cpp
       numpy/numpy.cpp numpy/scalars.cpp numpy/ufunc.cpp
     )
-  endif(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION GREATER 62)
+  endif(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION GREATER 62 AND ALPS_HAVE_BOOST_NUMPY)
   foreach(S ${SOURCES})
     if(EXISTS ${DIRECTORY}/${S})
       set(BOOST_PYTHON_SOURCES ${BOOST_PYTHON_SOURCES} ${DIRECTORY}/${S})


### PR DESCRIPTION
## Summary

- Adds `ALPS_USE_SYSTEM_BOOST` CMake option (default `OFF`) to consume a
  system- or Spack-installed precompiled Boost instead of downloading and
  building Boost from source at configure time.
- Adds graceful NumPy 2.0 fallback for Boost 1.63–1.86: when the system
  Boost predates the NumPy 2.0 fixes (requires Boost ≥ 1.87), ALPS now
  emits a `WARNING` and sets `ALPS_HAVE_BOOST_NUMPY OFF`, falling back to
  `boost::python::numeric::array` instead of failing the build.
- Guards the `src/boost` numpy sources behind `ALPS_HAVE_BOOST_NUMPY` so
  they are not compiled when the fallback is active.

## Changes

### `config/FindBoostForALPS.cmake`
- New `ALPS_USE_SYSTEM_BOOST` option; when `ON`:
  - Forces CMake module mode (`Boost_NO_BOOST_CMAKE=TRUE`, `CMP0167=OLD`)
    to avoid conflicts with `BoostConfig.cmake` in CMake 3.30+.
  - Probes `python<ver>/python3/python` and `numpy<ver>/numpy3/numpy`
    component names; saves/restores `Boost_LIBRARIES` around each probe
    (CMake overwrites it on every `find_package` call).
  - Adds `Boost_LIBRARY_DIRS` to `link_directories` so `@rpath` transitive
    dependencies (`libboost_graph`, `libboost_container`) resolve on macOS.
  - Applies scenario-3 fallback: Boost 1.63–1.86 + NumPy ≥ 2.0 → warning
    + `ALPS_HAVE_BOOST_NUMPY OFF`.

### `config/FindBoostSrc.cmake`
- Changed `FATAL_ERROR` for scenario 3 (old Boost + NumPy ≥ 2.0 in the
  source-build path) to `WARNING` + `set(ALPS_HAVE_BOOST_NUMPY OFF)`.

### `src/boost/CMakeLists.txt`
- NumPy source files (`numpy/dtype.cpp` etc.) now compiled only when
  `ALPS_HAVE_BOOST_NUMPY` is `ON`.

## Test plan

- [x] `spack install alps@develop~mpi ^boost@1.87.0 ^py-numpy@2.0.0` builds and passes `import pyalps; import pyalps.alea`
- [x] Default source-build (`ALPS_USE_SYSTEM_BOOST=OFF`) with Python+MPI — builds clean
- [x] Default source-build with MPI off (`ALPS_ENABLE_MPI=OFF`) — builds clean
- [x] Default source-build with Python off (`ALPS_BUILD_PYTHON=OFF`) — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)