### PR TITLE
Add CONTRIBUTING.md and pull request template (addresses ALPSim/alpsim.github.io#81)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## Summary
+
+<!-- What does this PR do and why? One or two sentences. -->
+
+## Type of change
+
+<!-- Check all that apply -->
+
+- [ ] Bug fix
+- [ ] New feature or algorithm
+- [ ] Documentation or tutorial improvement
+- [ ] Build system / dependency update
+- [ ] Refactor (no behaviour change)
+- [ ] Other: <!-- describe -->
+
+## Testing
+
+<!-- How was this tested? Check all that apply and describe any manual steps. -->
+
+- [ ] Existing tests pass (`ctest --output-on-failure`)
+- [ ] New tests added for changed behaviour
+- [ ] Results verified against known reference values or published results
+- [ ] Tested on Linux
+- [ ] Tested on macOS
+
+## For simulation code changes
+
+<!-- If this PR adds or modifies a simulation method, please complete this section. Skip if not applicable. -->
+
+- [ ] Physical results match expected behaviour (describe briefly below)
+- [ ] Parameter files / input format changes are documented
+- [ ] Relevant tutorial or documentation updated
+
+<!-- Brief description of physical validation, if applicable: -->
+
+## Checklist
+
+- [ ] CI passes (build + tests on all platforms)
+- [ ] No new compiler warnings (`-Wall -Wextra`)
+- [ ] Code follows the style of the surrounding code
+- [ ] Commit messages are descriptive and in the imperative mood
+
+## Related issues
+
+<!-- Link any related issues: "Closes #...", "Related to #..." -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,198 @@
+# Contributing to ALPS
+
+Thank you for your interest in ALPS (Algorithms and Libraries for Physics Simulations).
+ALPS is a community-driven, open-source ecosystem for numerical simulations of correlated quantum systems.
+Contributions at every level — from a one-line bug report to a new simulation method — are welcome and valued.
+
+## Table of contents
+
+- [Ways to contribute](#ways-to-contribute)
+- [Reporting bugs and requesting features](#reporting-bugs-and-requesting-features)
+- [Getting started with the code](#getting-started-with-the-code)
+- [Making a change](#making-a-change)
+- [Submitting a pull request](#submitting-a-pull-request)
+- [Review process](#review-process)
+- [Code style](#code-style)
+- [Recognition](#recognition)
+- [Getting help](#getting-help)
+
+---
+
+## Ways to contribute
+
+Contributions fall into four broad levels. You do not need to start at the bottom — jump in wherever your skills fit.
+
+| Level | What this looks like |
+|---|---|
+| **1 — Feedback** | Install ALPS, try a tutorial, open an issue when something is unclear or broken |
+| **2 — Documentation & tutorials** | Improve or extend tutorials on the [ALPS website](https://alps.comp-phys.org), fix documentation errors, add examples |
+| **3 — Maintenance** | Fix bugs, improve tests, update dependencies, respond to community questions on Discord |
+| **4 — New code** | Contribute a new algorithm, library, or simulation application |
+
+All contributions require agreeing to release your work under the [MIT License](LICENSE.txt).
+
+---
+
+## Reporting bugs and requesting features
+
+Use the [GitHub issue tracker](https://github.com/ALPSim/ALPS/issues). Choose the template that best fits:
+
+- **Bug report** — something is broken or produces wrong results
+- **Feature request** — you would like new functionality
+- **Simulation help** — you need help setting up a specific model, lattice, or method
+- **Website help** — problems with the alps.comp-phys.org website
+
+Before opening a new issue, please search existing issues to avoid duplicates.
+
+---
+
+## Getting started with the code
+
+### Prerequisites
+
+- CMake ≥ 3.18
+- A C++17-capable compiler (GCC, Clang, Intel, or Fujitsu)
+- Boost (bundled copy included; or provide your own with `-DALPS_USE_SYSTEM_BOOST=ON`)
+- For Fortran bindings: gfortran (or compatible Fortran compiler)
+- For Python bindings: Python ≥ 3.9, plus `numpy` and `scipy`
+
+See the [installation page](https://alps.comp-phys.org/documentation/install/) for full platform-specific instructions.
+
+### Fork and clone
+
+1. Fork the repository on GitHub.
+2. Clone your fork locally:
+   ```bash
+   git clone https://github.com/<your-username>/ALPS.git
+   cd ALPS
+   ```
+3. Add the upstream remote so you can stay up to date:
+   ```bash
+   git remote add upstream https://github.com/ALPSim/ALPS.git
+   ```
+
+### Build
+
+```bash
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+```
+
+To build with Python bindings:
+```bash
+pip install scikit-build-core numpy scipy
+pip install --no-build-isolation -e .
+```
+
+### Run the tests
+
+From the build directory:
+```bash
+ctest --output-on-failure
+```
+
+All tests must pass before submitting a pull request.
+
+---
+
+## Making a change
+
+1. **Sync with upstream** before starting work:
+   ```bash
+   git fetch upstream
+   git checkout master
+   git merge upstream/master
+   ```
+
+2. **Create a branch** named after what you are doing:
+   ```bash
+   git checkout -b fix/alea-overflow
+   git checkout -b feature/dmrg-excited-states
+   git checkout -b docs/tutorial-heisenberg
+   ```
+
+3. **Make your changes.** Keep commits focused and self-contained. Write commit messages in the imperative mood:
+   ```
+   fix: prevent integer overflow in alea accumulator
+   feat: add excited-state targeting to DMRG
+   docs: add Heisenberg chain tutorial
+   ```
+
+4. **Add or update tests** for any changed behaviour. New simulation methods should include at least one regression test comparing output against a known result.
+
+---
+
+## Submitting a pull request
+
+1. Push your branch to your fork:
+   ```bash
+   git push origin fix/alea-overflow
+   ```
+
+2. Open a pull request against the `master` branch of `ALPSim/ALPS`.
+
+3. Fill in the pull request template, including:
+   - What problem this solves and why
+   - How to test the change
+   - Any known limitations or follow-up work
+
+4. Ensure CI passes (build + tests on Linux and macOS).
+
+For substantial changes — new simulation applications, new libraries, significant API modifications — we encourage you to **open an issue or start a discussion first** to get early feedback before investing significant time.
+
+---
+
+## Review process
+
+ALPS uses a consensus-based review model:
+
+- Pull requests are reviewed by **maintainers** (at least one per simulation code) and **core maintainers**.
+- A pull request is accepted if all active reviewers approve, or if no objections are raised within **six weeks** of submission.
+- Controversial changes can be escalated to the [Governing Council](https://alps.comp-phys.org/govern/).
+
+Core maintainers are responsible for validating that code compiles, tests pass, and results are physically correct. Please be responsive to review comments; PRs with no author activity for eight weeks may be closed.
+
+If you are contributing a new simulation application or library, the Governing Council will discuss a maintenance commitment with you — typically a few hours per month for bug fixes, dependency updates, and community support.
+
+---
+
+## Code style
+
+### C++
+
+- Target C++17.
+- Match the style of the surrounding code. ALPS does not enforce a single formatter, but keeps consistent conventions within each subdirectory.
+- Avoid undefined behaviour and compiler warnings. New code should compile cleanly with `-Wall -Wextra` on GCC and Clang.
+- Prefer standard library and Boost facilities over hand-rolled implementations.
+
+### Python
+
+- Follow [PEP 8](https://peps.python.org/pep-0008/).
+- Type annotations are encouraged for new public functions.
+
+### CMake
+
+- CMake ≥ 3.18 features are acceptable.
+- Use target-based linking (`target_link_libraries`, `target_include_directories`) rather than directory-level commands.
+
+---
+
+## Recognition
+
+ALPS releases are accompanied by a publication in a peer-reviewed journal. **Active contributors are added as co-authors.** The Governing Council decides the author list for each release, taking into account contributions to code, documentation, tutorials, testing, and community support.
+
+Contributing documentation, tutorials, or code (Level 2 — improving or extending tutorials and website documentation — or above) with sustained effort is the typical threshold for co-authorship consideration.
+
+---
+
+## Getting help
+
+| Channel | Use it for |
+|---|---|
+| [Discord](https://discord.gg/JRNWnnva9g) | Questions about using ALPS, development discussion, meeting the community |
+| [GitHub Issues](https://github.com/ALPSim/ALPS/issues) | Bug reports, feature requests, concrete problems with the code |
+| [ALPS website](https://alps.comp-phys.org) | Documentation, tutorials, governance, events |
+| [Governing Council](https://alps.comp-phys.org/govern/) | Onboarding for new simulation codes, co-authorship, major contributions |
+
+We look forward to your contribution!


### PR DESCRIPTION
## Summary

Addresses ALPSim/alpsim.github.io#81. Adds standard contributor onboarding infrastructure to the ALPS code repository.

- **`CONTRIBUTING.md`**: covers contribution levels, prerequisites and build instructions, the fork/branch/PR workflow, commit message conventions, testing expectations, the 6-week consensus review model, code style (C++17, PEP 8, target-based CMake), and the co-authorship recognition policy.
- **`.github/pull_request_template.md`**: structured PR checklist covering change type, testing (ctest, new tests, reference validation, platform coverage), physical validation for simulation changes, and style/CI requirements.

The companion PR on the website ([ALPSim/alpsim.github.io](https://github.com/ALPSim/alpsim.github.io)) adds a "Contributing to ALPS" page under `/govern/contribute/` and updates the governance page to link here.

## Test plan

- [ ] Verify `CONTRIBUTING.md` renders correctly on GitHub (headings, table, code blocks)
- [ ] Open a test PR and confirm the pull request template pre-populates correctly
- [ ] Check all links in `CONTRIBUTING.md` resolve (Discord, GitHub Issues, installation page, governance page)