### PR TITLE
maxent: fill all nfreq+1 knots of the linear frequency grid

### DIFF
--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -135,6 +135,13 @@ endif(SQLite_FOUND)
     add_executable(maxent maxent.cpp maxent_helper.cpp maxent_simulation.cpp maxent_parms.cpp)
     target_link_libraries(maxent alps ${LAPACK_LIBRARY} ${BLAS_LIBRARY})
     install(TARGETS maxent RUNTIME DESTINATION bin COMPONENT tools)
+
+    # Regression test: linear-FREQUENCY_GRID runs must produce a finite
+    # spectrum (guards the t_array_ knot fill in maxent_parms.cpp).
+    add_executable(maxent_linear_grid_numeric maxent_linear_grid_numeric.cpp
+                   maxent_helper.cpp maxent_simulation.cpp maxent_parms.cpp)
+    target_link_libraries(maxent_linear_grid_numeric alps ${LAPACK_LIBRARY} ${BLAS_LIBRARY})
+    add_alps_test(maxent_linear_grid_numeric)
    endif(LAPACK_FOUND)
 
   #

--- a/tool/maxent_linear_grid_numeric.cpp
+++ b/tool/maxent_linear_grid_numeric.cpp
@@ -1,0 +1,133 @@
+// Numerical regression test for the linear FREQUENCY_GRID of the maxent
+// tool. ContiParameters allocates t_array_ with nfreq_+1 knots; leaving the
+// last knot unwritten corrupts the final bin width to ~(OMEGA_MIN-OMEGA_MAX),
+// which blows the default-model normalisation up to +-inf and makes every
+// linear-grid run return an all-NaN spectrum.
+//
+// The test synthesises a clean fermionic G(tau) from a known two-Gaussian
+// spectral function (peaks at omega = +-1.5), runs MaxEntSimulation
+// in-process on the linear grid, and asserts the recovered spectrum is
+// finite and satisfies the sum rule int A(omega) domega ~= 1.
+#include "maxent.hpp"
+
+#include <alps/hdf5/archive.hpp>
+#include <alps/hdf5/vector.hpp>
+#include <alps/ngs/params.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+bool all_finite(const std::vector<double>& v) {
+  if (v.empty()) return false;
+  for (std::size_t i = 0; i < v.size(); ++i)
+    if (!std::isfinite(v[i])) return false;
+  return true;
+}
+double trapz(const std::vector<double>& x, const std::vector<double>& y) {
+  double s = 0.0;
+  for (std::size_t i = 0; i + 1 < y.size(); ++i)
+    s += 0.5 * (y[i] + y[i + 1]) * (x[i + 1] - x[i]);
+  return s;
+}
+}
+
+int main() {
+  const double beta = 10.0;
+  const int n_tau = 40;
+  const int nom = 401;
+  const double om_lo = -8.0, om_hi = 8.0;
+
+  std::vector<double> tau(n_tau), om(nom), rho(nom);
+  for (int i = 0; i < n_tau; ++i) tau[i] = beta * double(i) / double(n_tau - 1);
+  for (int j = 0; j < nom; ++j) om[j] = om_lo + (om_hi - om_lo) * double(j) / double(nom - 1);
+  const double dom = om[1] - om[0];
+  for (int j = 0; j < nom; ++j)
+    rho[j] = std::exp(-std::pow(om[j] - 1.5, 2) / 0.4)
+           + std::exp(-std::pow(om[j] + 1.5, 2) / 0.4);
+  double rho_int = 0.0;
+  for (int j = 0; j + 1 < nom; ++j) rho_int += 0.5 * (rho[j] + rho[j + 1]) * dom;
+  for (int j = 0; j < nom; ++j) rho[j] /= rho_int;
+
+  std::vector<double> Gin(n_tau);
+  for (int i = 0; i < n_tau; ++i) {
+    double acc = 0.0;
+    for (int j = 0; j < nom; ++j)
+      acc += std::exp(-tau[i] * om[j]) / (1.0 + std::exp(-beta * om[j])) * rho[j];
+    Gin[i] = -acc * dom;
+  }
+  std::vector<double> errors(n_tau, 1e-3);
+
+  alps::params p;
+  p["BETA"] = beta;
+  p["NDAT"] = n_tau;
+  p["NFREQ"] = 400;
+  p["NORM"] = 1.0;
+  p["KERNEL"] = std::string("fermionic");
+  p["DATASPACE"] = std::string("time");
+  p["OMEGA_MIN"] = om_lo;
+  p["OMEGA_MAX"] = om_hi;
+  p["N_ALPHA"] = 12;
+  p["ALPHA_MIN"] = 0.1;
+  p["ALPHA_MAX"] = 100.0;
+  p["DEFAULT_MODEL"] = std::string("flat");
+  p["FREQUENCY_GRID"] = std::string("linear");
+  p["MAX_IT"] = 40;
+  p["PARTICLE_HOLE_SYMMETRY"] = 0;
+  p["TEXT_OUTPUT"] = 0;
+  p["DATA_IN_HDF5"] = 1;
+  p["MAX_TIME"] = 600;
+  p["VERBOSE"] = 0;
+
+  const char* tmpdir = std::getenv("TMPDIR");
+  std::string base = std::string(tmpdir ? tmpdir : "/tmp") + "/maxent_lock_check";
+  const std::string in_h5 = base + ".h5";
+  const std::string out_h5 = base + ".out.h5";
+  p["DATA"] = in_h5;
+  {
+    alps::hdf5::archive ar(in_h5, "w");
+    ar << alps::make_pvp("/Data", Gin);
+    ar << alps::make_pvp("/Error", errors);
+  }
+  std::remove(out_h5.c_str());
+
+  {
+    MaxEntSimulation sim(p, out_h5);
+    sim.run(boost::function<bool()>([]() { return false; }));
+  }
+
+  std::vector<double> w, Aavg, Amax, Achi;
+  {
+    alps::hdf5::archive ar(out_h5, "r");
+    ar >> alps::make_pvp("/spectrum/omega", w);
+    ar >> alps::make_pvp("/spectrum/average", Aavg);
+    ar >> alps::make_pvp("/spectrum/maximum", Amax);
+    ar >> alps::make_pvp("/spectrum/chi", Achi);
+  }
+
+  int failures = 0;
+  #define REQUIRE(cond, msg) do { if (!(cond)) { std::fprintf(stderr, "FAIL: %s\n", msg); ++failures; } } while (0)
+
+  REQUIRE(!w.empty(), "omega grid empty");
+  REQUIRE(all_finite(w), "omega grid not finite");
+  REQUIRE(all_finite(Aavg), "A_average not all-finite (NaN regression)");
+  REQUIRE(all_finite(Amax), "A_maximum not all-finite (NaN regression)");
+  REQUIRE(all_finite(Achi), "A_chi2 not all-finite (NaN regression)");
+
+  if (all_finite(w) && all_finite(Aavg)) {
+    const double sumrule = trapz(w, Aavg);
+    std::fprintf(stderr, "sumrule = %.4f\n", sumrule);
+    REQUIRE(std::abs(sumrule - 1.0) < 0.05, "sum rule violated (expected ~1.0)");
+  }
+
+  if (failures) {
+    std::fprintf(stderr, "maxent_lock_check: %d check(s) FAILED\n", failures);
+    return 1;
+  }
+  std::fprintf(stderr, "maxent_lock_check: PASS\n");
+  return 0;
+}

--- a/tool/maxent_parms.cpp
+++ b/tool/maxent_parms.cpp
@@ -95,8 +95,17 @@ y_(ndat_),sigma_(ndat_), x_(ndat_),K_(),t_array_(nfreq_+1)
       }
   }
   else if (p_f_grid=="linear") {
-    for (int i=0; i<nfreq_; ++i) 
-      t_array_[i] = double(i)/(nfreq_-1);
+    // t_array_ holds nfreq_+1 knots spanning [0,1]; MaxEntParameters reads
+    // t_array_[i] and t_array_[i+1] for i in [0,nfreq_) to build
+    // omega_coord_ and delta_omega_, so all nfreq_+1 knots must be filled —
+    // as the Lorentzian and log branches above do. Stopping at nfreq_ left
+    // the last knot unwritten; with that knot at 0 the last bin width
+    // becomes omega_of_t(0) - omega_of_t(t_array_[nfreq_-1]), i.e. about
+    // OMEGA_MIN - OMEGA_MAX — large and negative — which collapses the
+    // default-model normalisation and turns every linear-grid run into a
+    // NaN spectrum.
+    for (int i=0; i<nfreq_+1; ++i)
+      t_array_[i] = double(i)/(nfreq_);
   }
   else 
     boost::throw_exception(std::invalid_argument("No valid frequency grid specified"));


### PR DESCRIPTION
## Problem

Every MaxEnt run on the default **linear** `FREQUENCY_GRID` returns an all-NaN spectral function.

`ContiParameters` allocates `t_array_` with `nfreq_+1` knots, and `MaxEntParameters` consumes `t_array_[i]` together with `t_array_[i+1]` for every `i in [0, nfreq_)` when building `omega_coord_` and `delta_omega_`. The `"linear"` branch in `tool/maxent_parms.cpp`, however, only writes the first `nfreq_` knots (with spacing `1/(nfreq_-1)`), leaving `t_array_[nfreq_]` at its default 0.

The final bin therefore gets `delta_omega_[nfreq_-1] ≈ OMEGA_MIN − OMEGA_MAX` — a large negative width on an otherwise positive grid. That single negative entry drives the default-model integral to ~0, the `1/sum` normalisation blows every default-model entry up to ±inf, the transform into singular space produces NaN, and the solver diverges to an all-NaN spectrum. Reproducible with stock parameters (`FREQUENCY_GRID=linear`, any `NFREQ`), independent of data, default model, or alpha schedule.

## Fix

Fill all `nfreq_+1` knots as `i/nfreq_` over `[0,1]`, exactly as the Lorentzian and log branches already do. This also makes the knot spacing consistent with the t-integration the kernel assumes.

## How to reproduce

The PR ships the reproducer as a registered test, `tool/maxent_linear_grid_numeric`: it synthesises a clean fermionic G(τ) from a known two-Gaussian spectral function (peaks at ω = ±1.5) and runs `MaxEntSimulation` in-process on the linear grid.

```sh
# from your usual build directory
cmake --build . --target maxent_linear_grid_numeric
ctest -R maxent_linear_grid_numeric --output-on-failure
```

- **on master** (revert the one-hunk `maxent_parms.cpp` change to see it): the test fails with `FAIL: A_average not all-finite (NaN regression)` (likewise `A_maximum`, `A_chi2`); the solver logs `Q = nan`, `norm: nan`
- **with the fix**: passes — finite spectrum, two symmetric peaks recovered, sum rule ∫A(ω)dω = 1.0009

The bug is equally visible in any real linear-grid maxent run (`FREQUENCY_GRID=linear`, any `NFREQ`, any data): the output spectrum is all-NaN.

## Provenance

Found and fixed in a downstream ALPS modernization fork while root-causing reproducible NaN output of the maxent tool; the fix is identical there and is pinned by a deterministic two-peak regression test.
