### PR TITLE
dmft/hybridization: apply the MC sign once in measure_Gl

### DIFF
--- a/applications/dmft/qmc/hybridization/hybmatrix.cpp
+++ b/applications/dmft/qmc/hybridization/hybmatrix.cpp
@@ -333,7 +333,11 @@ void hybmatrix::measure_Gl(std::vector<double> &Gl, std::vector<double> &Fl , co
   for (int i = 0; i < size(); i++) {
     double f_pref=(F_prefactor.find(c_times[i]))->second;
     for (int j = 0; j < size(); j++) {
-      double M_ji = operator() (j, i) * sign;
+      // The MC sign enters exactly once, via bubble_sign below — the same
+      // convention as measure_G and measure_Gw. Multiplying it into M_ji as
+      // well squares it away (sign^2 = 1), which made the Legendre channel
+      // sign-independent and biased in signful runs.
+      double M_ji = operator() (j, i);
       double argument = c_times[i] - cdagger_times[j];
       double bubble_sign = sign;
       if (argument < 0) {


### PR DESCRIPTION
## Problem

`hybmatrix::measure_Gl` multiplies the Monte Carlo configuration sign into **both** factors of every contribution: once into `M_ji` and once into `bubble_sign`:

```cpp
double M_ji = operator() (j, i) * sign;
...
double bubble_sign = sign;            // (flipped on tau wraparound)
...
double gl = M_ji*legendre_p*bubble_sign;   // carries sign^2 = 1
```

Each accumulated term therefore carries sign² = 1, so the Legendre estimators `Gl`/`Fl` ignore the configuration sign entirely — while `measure_G` (binned τ) and `measure_Gw` (Matsubara) apply it exactly once via `bubble_sign`. In any run with ⟨sign⟩ ≠ 1 the Legendre channel accumulates the unweighted average while the other channels accumulate the sign-weighted numerator: the channels are mutually inconsistent and `Gl`/`Fl` are biased.

## Fix

One line: drop the sign from `M_ji`, so it enters exactly once through `bubble_sign`, matching `measure_G`/`measure_Gw`. The τ-wraparound anticommutator flip on `bubble_sign` is unchanged.

Sign-free runs (the common density-density segment case, where sign = 1 throughout) are **bit-identical** — which is how this survived; `MEASURE_legendre` also defaults off.

## How to verify

There is deliberately no runtime reproducer in this PR: exercising the bug end-to-end needs a model with ⟨sign⟩ ≠ 1 *and* `MEASURE_legendre=1`, and there is no signful reference result in-tree to compare against. The bug is instead verifiable by inspection in under a minute at the quoted lines of `measure_Gl`: `M_ji` carries `sign`, `bubble_sign` carries `sign` again, and every accumulated term is `M_ji * legendre_p * bubble_sign` — so the configuration sign enters squared and cancels identically, while `measure_G`/`measure_Gw` in the same file apply it exactly once via `bubble_sign`. Equivalently: flip the sign of `sign` at the call site and observe that `Gl`/`Fl` are unchanged while `G`/`Gw` negate.

The downstream fork pins the fix with a sign-linearity test: a deterministic two-operator-pair hybridization matrix built through the production insert path must satisfy `measure(sign=−1) == −measure(sign=+1)` elementwise for all of G/F/Gl/Fl. Before the change Gl/Fl return identical values for both signs (G/F already pass); after it all four channels are exactly sign-antisymmetric. (That test rig depends on fork-side scaffolding and is not ported here; happy to port it if wanted.) The solver builds cleanly with the change on current master (`73b331006`).

## Provenance

Found in a systematic estimator audit in a downstream ALPS modernization fork; the fix is identical there and covered by the sign-linearity lock described above.
