### PR TITLE
dmrg: refuse MEASURE_* parameters with a clear error instead of SIGSEGV

### DIFF
--- a/applications/dmrg/dmrg/dmrg.h
+++ b/applications/dmrg/dmrg/dmrg.h
@@ -269,7 +269,36 @@ void DMRGTask<value_type>::dostep()
 {
   if (finished()) 
     return;
-  
+
+  // The measurement-rotation path (dmtk::System::rotate_hami) dereferences
+  // the result of System::operator()(op) without a null check. operator()
+  // legitimately returns 0 when a measurement operator's site is not yet
+  // covered by the current b1..b4 block layout for a given final_sweep
+  // iteration -- which is always the case during the first iterations for
+  // sites near the chain endpoints. Every input requesting MEASURE_LOCAL /
+  // MEASURE_AVERAGE / MEASURE_CORRELATIONS / MEASURE_STRUCTURE_FACTOR
+  // therefore crashes with SIGSEGV before producing any output.
+  //
+  // A correct fix needs the block operator-set bookkeeping re-derived so
+  // measurement operators are guaranteed present at every iteration. Until
+  // then, refuse the request with a clear error instead of crashing.
+  // (The mps_optim application, which supported the same MEASURE_* syntax,
+  // was removed from this repository; releases up to and including the last
+  // one that shipped it can be used for these measurements.)
+  if (!this->local_expressions.empty()
+      || !this->average_expressions.empty()
+      || !this->correlation_expressions.empty()
+      || !this->structurefactor_expressions.empty()) {
+    boost::throw_exception(std::runtime_error(
+        "MEASURE_LOCAL / MEASURE_AVERAGE / MEASURE_CORRELATIONS / "
+        "MEASURE_STRUCTURE_FACTOR are not supported by the classic 'dmrg' "
+        "binary: the legacy DMTK measurement path dereferences a null "
+        "operator lookup in dmtk::System::rotate_hami and crashes. Remove "
+        "the MEASURE_* parameters to compute the energy/entropy only, or "
+        "use the 'mps_optim' application from an ALPS release that still "
+        "ships it to evaluate these observables."));
+  }
+
   dmtk::Lattice l(num_sites(),dmtk::OBC);
   hami = dmtk::Hami<value_type >(l);
   site_block.resize(alps::maximum_vertex_type(graph())+1);


### PR DESCRIPTION
## Problem

The classic `dmrg` binary crashes with SIGSEGV on every input that requests `MEASURE_LOCAL`, `MEASURE_AVERAGE`, `MEASURE_CORRELATIONS`, or `MEASURE_STRUCTURE_FACTOR`: `dmtk::System::rotate_hami` dereferences the result of `System::operator()(op)` without a null check, and the lookup legitimately returns 0 while a measurement operator's site is not yet covered by the current block layout during early `final_sweep` iterations near the chain endpoints. Diagnosed with lldb: `BasicOp::is_diagonal` called on `this == 0x0` via `rotate_hami`.

A skip-null guard at the call sites is **not** a fix: it compiles but silently drops legitimate measurement terms wholesale (a `Sz_total=2` local-Sz sum comes out as 0.15 instead of 2). Correctly fixing the legacy path needs the block operator-set bookkeeping re-derived so measurement operators are guaranteed present at every iteration.

## Fix

Until someone does that surgery, fail fast in `DMRGTask::dostep` with an actionable message when any `MEASURE_*` parameter is present. Since #92 removed the `mps_optim` application (which supported the same `MEASURE_*` syntax), the message suggests dropping the `MEASURE_*` parameters (energy/entropy still work) or using an ALPS release that still ships `mps_optim`.

## How to reproduce

Save as `parm`:

```
LATTICE="open chain lattice"
MODEL="spin"
local_S=1/2
CONSERVED_QUANTUMNUMBERS="Sz"
Sz_total=0
J=1
L=8
SWEEPS=2
NUMBER_EIGENVALUES=1
MAXSTATES=32
MEASURE_LOCAL[Local Sz]=Sz
{}
```

```sh
parameter2xml parm
dmrg parm.in.xml ; echo "exit=$?"
```

- **on master**: `exit=139` (SIGSEGV) mid-sweep, empty stderr
- **with the fix**: clean nonzero exit with a single-line explanation of what is unsupported and why
- delete the `MEASURE_LOCAL` line and the identical run completes unchanged (`exit=0`) — the guard only fires when a `MEASURE_*` parameter is present

The same crash reproduces with `MEASURE_AVERAGE`, `MEASURE_CORRELATIONS`, and `MEASURE_STRUCTURE_FACTOR` (the old dmrg-03/dmrg-04 tutorial inputs were public reproducers before the tutorials were removed).

## Provenance

Diagnosed and guarded in a downstream ALPS modernization fork, where the guard is pinned by an API regression test asserting the non-signal exit code and the actionable stderr text.
