### PR TITLE
Bump GitHub Actions to Node.js 24 releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,9 +66,9 @@ jobs:
         - { os: ubuntu-24.04, comp_pack: "gcc-14 g++-14", c_compiler: gcc, cxx_compiler: g++, c_version: 14, py_version: "3.14", boost_version: 91, cxx_standard: 23 }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.plat.py_version }}
       - name: Install dependencies
@@ -122,7 +122,7 @@ jobs:
         - { os: macos-15, c_compiler: gcc-14, cxx_compiler: g++-14, comp_pack: "gcc@14", cxx_stdlib: "", py_version: "3.14", boost_version: 91 }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install dependencies
         run: |
           brew install python@${{ matrix.plat.py_version }} gfortran
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs-${{ github.run_id }}
           path: |

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,7 +24,7 @@ jobs:
         - { os: macos-26, target: "26.0" , arch: arm64, homebrew: '/opt/homebrew'}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Install Fortran compiler based on OS
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
         #   output-dir: wheelhouse
         #   config-file: "{package}/pyproject.toml"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.plat.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -72,12 +72,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -93,7 +93,7 @@ jobs:
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     if: startsWith(github.ref, 'refs/tags/v')  || github.event_name == 'release'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           # unpacks all CIBW artifacts into dist/
           pattern: cibw-*


### PR DESCRIPTION
## Summary
- GitHub Actions runs were showing `Node.js 20 is deprecated` warnings for `actions/checkout@v4` and `actions/upload-artifact@v4`.
- Bumped all affected actions to their current major versions, which run on Node.js 24 (`runs.using: node24`):
  - `actions/checkout` v4 -> v7
  - `actions/setup-python` v5 -> v7
  - `actions/upload-artifact` v4 -> v7
  - `actions/download-artifact` v4 -> v8
- Checked each action's release notes between the old and new majors; no breaking changes apply to how this repo uses them (no single-artifact-by-ID downloads, no `pip-install` input, standard name/pattern-based artifact up/download).

## Test plan
- [ ] CI run on this PR completes without the Node.js 20 deprecation warning
- [ ] Existing build/test/upload-artifact steps succeed as before
