### PR TITLE
fix: stop version.h dropping zero-valued version components

### DIFF
--- a/src/alps/version.h.in
+++ b/src/alps/version.h.in
@@ -30,34 +30,46 @@
 #ifndef ALPS_VERSION_H
 #define ALPS_VERSION_H
 
-// ALPS version
-#cmakedefine ALPS_VERSION "@ALPS_VERSION@"
+// Plain #define for everything the build always sets: the cmakedefine directive
+// emits an "undef" when its value is false-y, and CMake counts 0 as false-y, so
+// a zero component (2.4.0) would vanish. It is used below only where the macro
+// is genuinely optional. (configure_file matches that directive even inside a
+// comment, hence no leading '#' on it here.)
 
-#cmakedefine ALPS_VERSION_MAJOR @ALPS_VERSION_MAJOR@
-#cmakedefine ALPS_VERSION_MINOR @ALPS_VERSION_MINOR@
-#cmakedefine ALPS_VERSION_PATCH @ALPS_VERSION_PATCH@
-#cmakedefine ALPS_SVN_REVISION @ALPS_WC_REVISION@
+// ALPS version
+#define ALPS_VERSION "@ALPS_VERSION@"
+
+#define ALPS_VERSION_MAJOR @ALPS_VERSION_MAJOR@
+#define ALPS_VERSION_MINOR @ALPS_VERSION_MINOR@
+#define ALPS_VERSION_PATCH @ALPS_VERSION_PATCH@
+
+// ALPS version as a single integer, for preprocessor comparisons:
+//   #if ALPS_VERSION_NUMBER >= ALPS_VERSION_NUM(2, 3, 4)
+#define ALPS_VERSION_NUM(major, minor, patch) \
+  ((major) * 100000 + (minor) * 100 + (patch))
+#define ALPS_VERSION_NUMBER \
+  ALPS_VERSION_NUM(ALPS_VERSION_MAJOR, ALPS_VERSION_MINOR, ALPS_VERSION_PATCH)
 
 // ALPS version (full string)
-#cmakedefine ALPS_VERSION_STRING "@ALPS_VERSION_STRING@"
+#define ALPS_VERSION_STRING "@ALPS_VERSION_STRING@"
 
 // latest publish year of ALPS
-#cmakedefine ALPS_YEAR "@ALPS_YEAR@"
+#define ALPS_YEAR "@ALPS_YEAR@"
 
 // install path of ALPS
-#cmakedefine ALPS_PREFIX "@ALPS_PREFIX@"
-
-// source directory of ALPS
-#cmakedefine ALPS_SRCDIR "@ALPS_SRCDIR@"
+#define ALPS_PREFIX "@ALPS_PREFIX@"
 
 // XSLT PATH
-#cmakedefine ALPS_XML_DIR "@ALPS_XML_DIR@"
+#define ALPS_XML_DIR "@ALPS_XML_DIR@"
+
+// Optional Windows fallback for the 32/64-bit "Program Files" split. Never set
+// by the build, and guarded by #ifdef in parser/xslt_path.C.
 #cmakedefine ALPS_XML_ALTERNATE_DIR "@ALPS_XML_ALTERNATE_DIR@"
 
 // hostname where configure script was executed
-#cmakedefine ALPS_CONFIG_HOST "@ALPS_CONFIG_HOST@"
+#define ALPS_CONFIG_HOST "@ALPS_CONFIG_HOST@"
 
 // username who executed configure script
-#cmakedefine ALPS_CONFIG_USER "@ALPS_CONFIG_USER@"
+#define ALPS_CONFIG_USER "@ALPS_CONFIG_USER@"
 
 #endif // ALPS_VERSION_H

--- a/tool/pconfig.C
+++ b/tool/pconfig.C
@@ -35,7 +35,6 @@
 int main() {
   std::cout << "ALPS version:          " << alps::version() << std::endl
             << "Boost version:         " << BOOST_LIB_VERSION << std::endl
-            << "source directory:      " << ALPS_SRCDIR << std::endl
             << "installed at:          " << ALPS_PREFIX << std::endl
             << "configured on:         " << alps::config_host() << std::endl
             << "configured by:         " << alps::config_user() << std::endl


### PR DESCRIPTION
`version.h.in` declared the version components with `cmakedefine`, which emits `/* #undef NAME */` when the substituted value is false-y. CMake counts `0` as false-y, so any `x.y.0` release generates an installed header with that component silently missing. We're at `v2.3.4-beta.2`, so 2.4.0 would have tripped it.

- Plain `#define` for every macro the build unconditionally sets. `cmakedefine` stays only for `ALPS_XML_ALTERNATE_DIR`, which the build never sets and `parser/xslt_path.C` guards with `#ifdef`.
- Add `ALPS_VERSION_NUMBER` / `ALPS_VERSION_NUM()` for preprocessor version checks, packed like `BOOST_VERSION`.
- Drop `ALPS_SVN_REVISION` (expanded `@ALPS_WC_REVISION@`, unset since the SVN migration, always `#undef`) and `ALPS_SRCDIR` (baked the build machine's source path into an installed header for one line of `pconfig` output).

Verified by generating the header at 2.4.0 and 2.3.4 and compiling against each. `set(ALPS_SRCDIR ...)` is left in `CMakeLists.txt` on purpose — that file is contested by #107/#110/#112, and the follow-up rewrites the block.

Refs #95. Scoped to the two files no other open PR touches, so it can merge independently of the #107 → #111 → #112 stack.
