### PR TITLE
Replace ALPS license boilerplate with project and SPDX notices (merge after #109)

### DIFF
--- a/applications/diag/diag.h
+++ b/applications/diag/diag.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Andreas Honecker <ahoneck@uni-goettingen.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/fulldiag/factory.C
+++ b/applications/diag/fulldiag/factory.C
@@ -5,23 +5,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Andreas Honecker <ahoneck@uni-goettingen.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/fulldiag/factory.h
+++ b/applications/diag/fulldiag/factory.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/fulldiag/fulldiag.C
+++ b/applications/diag/fulldiag/fulldiag.C
@@ -5,23 +5,8 @@
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Andreas Honecker <ahoneck@uni-goettingen.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/fulldiag/fulldiag.h
+++ b/applications/diag/fulldiag/fulldiag.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Andreas Honecker <ahoneck@uni-goettingen.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/fulldiag/fulldiag_evaluate.C
+++ b/applications/diag/fulldiag/fulldiag_evaluate.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2002-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Andreas Honecker <ahoneck@uni-goettingen.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/fulldiag/measurementplots.h
+++ b/applications/diag/fulldiag/measurementplots.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Andreas Honecker <ahoneck@uni-goettingen.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/fulldiagfqhe/fqheed.cpp
+++ b/applications/diag/fulldiagfqhe/fqheed.cpp
@@ -4,23 +4,8 @@
  *
  * Copyright (C) 2012 by Vito Scarola <scarola@vt.edu>
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/diag/fulldiagfqhe/states_lll.c
+++ b/applications/diag/fulldiagfqhe/states_lll.c
@@ -4,22 +4,8 @@
  *
  * Copyright (C) 2012 by Vito Scarola <scarola@vt.edu>
  *
- * This software is part of the ALPS Applications, published under the ALPS
- * Application License; you can use, redistribute it and/or modify it under
- * the terms of the license, either version 1 or (at your option) any later
- * version.
- *
- * You should have received a copy of the ALPS Application License along with
- * the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- * available from http://alps.comp-phys.org/.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * ALPS Project: https://alps.comp-phys.org/
+ * SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/diag/fulldiagfqhe/states_lll_mz_minus_one.c
+++ b/applications/diag/fulldiagfqhe/states_lll_mz_minus_one.c
@@ -4,22 +4,8 @@
  *
  * Copyright (C) 2012 by Vito Scarola <scarola@vt.edu>
  *
- * This software is part of the ALPS Applications, published under the ALPS
- * Application License; you can use, redistribute it and/or modify it under
- * the terms of the license, either version 1 or (at your option) any later
- * version.
- *
- * You should have received a copy of the ALPS Application License along with
- * the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- * available from http://alps.comp-phys.org/.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * ALPS Project: https://alps.comp-phys.org/
+ * SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/diag/fulldiagfqhe/vector_of_primes.c
+++ b/applications/diag/fulldiagfqhe/vector_of_primes.c
@@ -4,22 +4,8 @@
  *
  * Copyright (C) 2012 by Vito Scarola <scarola@vt.edu>
  *
- * This software is part of the ALPS Applications, published under the ALPS
- * Application License; you can use, redistribute it and/or modify it under
- * the terms of the license, either version 1 or (at your option) any later
- * version.
- *
- * You should have received a copy of the ALPS Application License along with
- * the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- * available from http://alps.comp-phys.org/.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * ALPS Project: https://alps.comp-phys.org/
+ * SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/diag/sparsediag/factory.C
+++ b/applications/diag/sparsediag/factory.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/sparsediag/factory.h
+++ b/applications/diag/sparsediag/factory.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1994-2004 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/sparsediag/sparsediag.C
+++ b/applications/diag/sparsediag/sparsediag.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1994-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/diag/sparsediag/sparsediag.h
+++ b/applications/diag/sparsediag/sparsediag.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/U_matrix.h
+++ b/applications/dmft/qmc/U_matrix.h
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/alps_solver.C
+++ b/applications/dmft/qmc/alps_solver.C
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/alps_solver.h
+++ b/applications/dmft/qmc/alps_solver.h
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/auxiliaryfunctions.C
+++ b/applications/dmft/qmc/auxiliaryfunctions.C
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/bandstructure.C
+++ b/applications/dmft/qmc/bandstructure.C
@@ -6,23 +6,8 @@
  *               2012 - 2013 by Jakub Imriska <jimriska@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
  

--- a/applications/dmft/qmc/bandstructure.h
+++ b/applications/dmft/qmc/bandstructure.h
@@ -5,23 +5,8 @@
  * Copyright (C) 2013        by Jakub Imriska <jimriska@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
  

--- a/applications/dmft/qmc/externalsolver.C
+++ b/applications/dmft/qmc/externalsolver.C
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/externalsolver.h
+++ b/applications/dmft/qmc/externalsolver.h
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/fouriertransform.C
+++ b/applications/dmft/qmc/fouriertransform.C
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/fouriertransform.h
+++ b/applications/dmft/qmc/fouriertransform.h
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/green_function.h
+++ b/applications/dmft/qmc/green_function.h
@@ -8,23 +8,8 @@
  *                              Sebastian Fuchs <fuchs@theorie.physik.uni-goettingen.de>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hilberttransformer.C
+++ b/applications/dmft/qmc/hilberttransformer.C
@@ -8,23 +8,8 @@
  *                            Sebastian Fuchs <fuchs@comp-phys.org>
  *               2012-2013 by Jakub Imriska <jimriska@phys.ethz.ch>
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hilberttransformer.h
+++ b/applications/dmft/qmc/hilberttransformer.h
@@ -9,23 +9,8 @@
  *               2012 - 2013 by Jakub Imriska <jimriska@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/hirschfyeaux.h
+++ b/applications/dmft/qmc/hirschfyeaux.h
@@ -7,23 +7,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hirschfyesim.C
+++ b/applications/dmft/qmc/hirschfyesim.C
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hirschfyesim.h
+++ b/applications/dmft/qmc/hirschfyesim.h
@@ -7,23 +7,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hyb.hpp
+++ b/applications/dmft/qmc/hybridization/hyb.hpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef HYB_HPP

--- a/applications/dmft/qmc/hybridization/hybblasmatrix.hpp
+++ b/applications/dmft/qmc/hybridization/hybblasmatrix.hpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef HYB_BLAS_MATRIX

--- a/applications/dmft/qmc/hybridization/hybconfig.cpp
+++ b/applications/dmft/qmc/hybridization/hybconfig.cpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybconfig.hpp
+++ b/applications/dmft/qmc/hybridization/hybconfig.hpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef HYB_CONFIG_HPP

--- a/applications/dmft/qmc/hybridization/hybevaluate.cpp
+++ b/applications/dmft/qmc/hybridization/hybevaluate.cpp
@@ -9,23 +9,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybevaluate.hpp
+++ b/applications/dmft/qmc/hybridization/hybevaluate.hpp
@@ -8,23 +8,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef HYB_EVALUATE

--- a/applications/dmft/qmc/hybridization/hybfun.cpp
+++ b/applications/dmft/qmc/hybridization/hybfun.cpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybfun.hpp
+++ b/applications/dmft/qmc/hybridization/hybfun.hpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybint.cpp
+++ b/applications/dmft/qmc/hybridization/hybint.cpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybint.hpp
+++ b/applications/dmft/qmc/hybridization/hybint.hpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hyblocal.cpp
+++ b/applications/dmft/qmc/hybridization/hyblocal.cpp
@@ -8,23 +8,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hyblocal.hpp
+++ b/applications/dmft/qmc/hybridization/hyblocal.hpp
@@ -8,23 +8,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef LOCAL_CONFIG_HPP

--- a/applications/dmft/qmc/hybridization/hybmain.cpp
+++ b/applications/dmft/qmc/hybridization/hybmain.cpp
@@ -8,23 +8,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybmatrix.cpp
+++ b/applications/dmft/qmc/hybridization/hybmatrix.cpp
@@ -8,23 +8,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybmatrix.hpp
+++ b/applications/dmft/qmc/hybridization/hybmatrix.hpp
@@ -8,23 +8,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef HYB_MATRIX

--- a/applications/dmft/qmc/hybridization/hybmatrix_ft.cpp
+++ b/applications/dmft/qmc/hybridization/hybmatrix_ft.cpp
@@ -8,23 +8,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybmeasurements.cpp
+++ b/applications/dmft/qmc/hybridization/hybmeasurements.cpp
@@ -8,23 +8,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybretintfun.cpp
+++ b/applications/dmft/qmc/hybridization/hybretintfun.cpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybretintfun.hpp
+++ b/applications/dmft/qmc/hybridization/hybretintfun.hpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/hybridization/hybsegment.hpp
+++ b/applications/dmft/qmc/hybridization/hybsegment.hpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef HYB_SEG_HPP

--- a/applications/dmft/qmc/hybridization/hybsim.cpp
+++ b/applications/dmft/qmc/hybridization/hybsim.cpp
@@ -8,23 +8,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef HYB_SIM_MAIN

--- a/applications/dmft/qmc/hybridization/hybupdates.cpp
+++ b/applications/dmft/qmc/hybridization/hybupdates.cpp
@@ -7,23 +7,8 @@
  *  based on an earlier version by Philipp Werner and Emanuel Gull
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #include <iomanip>

--- a/applications/dmft/qmc/interaction_expansion/auxiliary.cpp
+++ b/applications/dmft/qmc/interaction_expansion/auxiliary.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/fastupdate.cpp
+++ b/applications/dmft/qmc/interaction_expansion/fastupdate.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/green_matrix.hpp
+++ b/applications/dmft/qmc/interaction_expansion/green_matrix.hpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/interaction_expansion.cpp
+++ b/applications/dmft/qmc/interaction_expansion/interaction_expansion.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/interaction_expansion.hpp
+++ b/applications/dmft/qmc/interaction_expansion/interaction_expansion.hpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/io.cpp
+++ b/applications/dmft/qmc/interaction_expansion/io.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/measurements.cpp
+++ b/applications/dmft/qmc/interaction_expansion/measurements.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/model.cpp
+++ b/applications/dmft/qmc/interaction_expansion/model.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/observables.cpp
+++ b/applications/dmft/qmc/interaction_expansion/observables.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/operator.hpp
+++ b/applications/dmft/qmc/interaction_expansion/operator.hpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/selfenergy.cpp
+++ b/applications/dmft/qmc/interaction_expansion/selfenergy.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/solver.cpp
+++ b/applications/dmft/qmc/interaction_expansion/solver.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion/splines.cpp
+++ b/applications/dmft/qmc/interaction_expansion/splines.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/auxiliary.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/auxiliary.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/fastupdate.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/fastupdate.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/green_matrix.hpp
+++ b/applications/dmft/qmc/interaction_expansion2/green_matrix.hpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/interaction_expansion.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/interaction_expansion.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/interaction_expansion.hpp
+++ b/applications/dmft/qmc/interaction_expansion2/interaction_expansion.hpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/io.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/io.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/main.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/main.cpp
@@ -5,23 +5,8 @@
  * Copyright (C) 2005 - 2010 by Emanuel Gull <gull@phys.columbia.edu>,
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/measurements.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/measurements.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/model.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/model.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/observables.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/observables.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/operator.hpp
+++ b/applications/dmft/qmc/interaction_expansion2/operator.hpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/selfenergy.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/selfenergy.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/solver.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/solver.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/interaction_expansion2/splines.cpp
+++ b/applications/dmft/qmc/interaction_expansion2/splines.cpp
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/main.C
+++ b/applications/dmft/qmc/main.C
@@ -9,23 +9,8 @@
  *               2012 - 2013 by Jakub Imriska <jimriska@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/selfconsistency.C
+++ b/applications/dmft/qmc/selfconsistency.C
@@ -9,23 +9,8 @@
  *               2012 - 2013 by Jakub Imriska <jimriska@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/selfconsistency.h
+++ b/applications/dmft/qmc/selfconsistency.h
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/solver.h
+++ b/applications/dmft/qmc/solver.h
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/solver_main.C
+++ b/applications/dmft/qmc/solver_main.C
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/dmft/qmc/types.h
+++ b/applications/dmft/qmc/types.h
@@ -7,23 +7,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmft/qmc/xml.h
+++ b/applications/dmft/qmc/xml.h
@@ -8,23 +8,8 @@
  *                              Matthias Troyer <troyer@comp-phys.org>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmrg.C
+++ b/applications/dmrg/dmrg/dmrg.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *                             Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmrg.h
+++ b/applications/dmrg/dmrg/dmrg.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/array_util.h
+++ b/applications/dmrg/dmrg/dmtk/array_util.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/basis.h
+++ b/applications/dmrg/dmrg/dmtk/basis.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/bits.h
+++ b/applications/dmrg/dmrg/dmtk/bits.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/block.h
+++ b/applications/dmrg/dmrg/dmtk/block.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/block_matrix.h
+++ b/applications/dmrg/dmrg/dmtk/block_matrix.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/conj.h
+++ b/applications/dmrg/dmrg/dmtk/conj.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/constants.h
+++ b/applications/dmrg/dmrg/dmtk/constants.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/cslice_implement.h
+++ b/applications/dmrg/dmrg/dmtk/cslice_implement.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/ctimer.h
+++ b/applications/dmrg/dmrg/dmtk/ctimer.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/dmtk.h
+++ b/applications/dmrg/dmrg/dmtk/dmtk.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/enums.h
+++ b/applications/dmrg/dmrg/dmtk/enums.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/globals.h
+++ b/applications/dmrg/dmrg/dmtk/globals.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/gslice_implement.h
+++ b/applications/dmrg/dmrg/dmtk/gslice_implement.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/gslice_iter.h
+++ b/applications/dmrg/dmrg/dmtk/gslice_iter.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/hami.h
+++ b/applications/dmrg/dmrg/dmtk/hami.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/lanczos.cc
+++ b/applications/dmrg/dmrg/dmtk/lanczos.cc
@@ -4,22 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* This software is part of the ALPS Applications, published under the ALPS
-* Application License; you can use, redistribute it and/or modify it under
-* the terms of the license, either version 1 or (at your option) any later
-* version.
-* 
-* You should have received a copy of the ALPS Application License along with
-* the ALPS Applications; see the file LICENSE.txt. If not, the license is also
-* available from http://alps.comp-phys.org/.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/lapack_interface.h
+++ b/applications/dmrg/dmrg/dmtk/lapack_interface.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/lattice.h
+++ b/applications/dmrg/dmrg/dmtk/lattice.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/matrix.h
+++ b/applications/dmrg/dmrg/dmtk/matrix.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/matrix_implement.h
+++ b/applications/dmrg/dmrg/dmtk/matrix_implement.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/meta.h
+++ b/applications/dmrg/dmrg/dmtk/meta.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/operators.h
+++ b/applications/dmrg/dmrg/dmtk/operators.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/qn.h
+++ b/applications/dmrg/dmrg/dmtk/qn.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/range.h
+++ b/applications/dmrg/dmrg/dmtk/range.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/slice_implement.h
+++ b/applications/dmrg/dmrg/dmtk/slice_implement.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/slice_iter.h
+++ b/applications/dmrg/dmrg/dmtk/slice_iter.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/state.h
+++ b/applications/dmrg/dmrg/dmtk/state.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/state_slice.h
+++ b/applications/dmrg/dmrg/dmtk/state_slice.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/subspace.h
+++ b/applications/dmrg/dmrg/dmtk/subspace.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/system.h
+++ b/applications/dmrg/dmrg/dmtk/system.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/util.h
+++ b/applications/dmrg/dmrg/dmtk/util.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/vector.h
+++ b/applications/dmrg/dmrg/dmtk/vector.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/dmtk/vector_implement.h
+++ b/applications/dmrg/dmrg/dmtk/vector_implement.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2006 -2010 by Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/factory.C
+++ b/applications/dmrg/dmrg/factory.C
@@ -5,23 +5,8 @@
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Adrian Feiguin <afeiguin@uwyo.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/dmrg/dmrg/factory.h
+++ b/applications/dmrg/dmrg/factory.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/evaluator.C
+++ b/applications/mc/simple/evaluator.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/evaluator.h
+++ b/applications/mc/simple/evaluator.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/heisenberg.C
+++ b/applications/mc/simple/heisenberg.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/heisenberg.h
+++ b/applications/mc/simple/heisenberg.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/ising.C
+++ b/applications/mc/simple/ising.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/ising.h
+++ b/applications/mc/simple/ising.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/main.C
+++ b/applications/mc/simple/main.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/vtk.h
+++ b/applications/mc/simple/vtk.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2012-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/xy.C
+++ b/applications/mc/simple/xy.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/simple/xy.h
+++ b/applications/mc/simple/xy.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/abstract_fitter.C
+++ b/applications/mc/spins/abstract_fitter.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                       Andreas Streich <astreich@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/abstractspinsim.h
+++ b/applications/mc/spins/abstractspinsim.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1999-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Fabian Stoeckli <fabstoec@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/base_incr_fitter.C
+++ b/applications/mc/spins/base_incr_fitter.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                       Andreas Streich <astreich@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/clusterupdate.h
+++ b/applications/mc/spins/clusterupdate.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1999-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Fabian Stoeckli <fabstoec@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/connect.h
+++ b/applications/mc/spins/connect.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1999-2003 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/dummy_fitter.C
+++ b/applications/mc/spins/dummy_fitter.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                       Andreas Streich <astreich@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/est_grad_fitter.C
+++ b/applications/mc/spins/est_grad_fitter.C
@@ -6,23 +6,8 @@
 *                       Walter Gander <gander@inf.ethz.ch>,
 *                       Andreas Streich <astreich@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/factory.h
+++ b/applications/mc/spins/factory.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/faststack.h
+++ b/applications/mc/spins/faststack.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1999-2003 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/fit.C
+++ b/applications/mc/spins/fit.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                       Andreas Streich <astreich@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/fitter.h
+++ b/applications/mc/spins/fitter.h
@@ -5,23 +5,8 @@
 * Copyright (C) 2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                       Andreas Streich <astreich@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/fitting_scheduler.C
+++ b/applications/mc/spins/fitting_scheduler.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                       Andreas Streich <astreich@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/fitting_scheduler.h
+++ b/applications/mc/spins/fitting_scheduler.h
@@ -5,23 +5,8 @@
 * Copyright (C) 2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                       Andreas Streich <astreich@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/helper.h
+++ b/applications/mc/spins/helper.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C)  by Andreas Streich 
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/ising.h
+++ b/applications/mc/spins/ising.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1999-2003 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Fabian Stoeckli <fabstoec@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/lapack.h
+++ b/applications/mc/spins/lapack.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/localupdate.h
+++ b/applications/mc/spins/localupdate.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1999-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Fabian Stoeckli <fabstoec@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/matrices.h
+++ b/applications/mc/spins/matrices.h
@@ -5,23 +5,8 @@
 * Copyright (C) 2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                       Andreas Streich <astreich@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/on.h
+++ b/applications/mc/spins/on.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1999-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Fabian Stoeckli <fabstoec@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/potts.h
+++ b/applications/mc/spins/potts.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1999-2003 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Fabian Stoeckli <fabstoec@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/spinmc.C
+++ b/applications/mc/spins/spinmc.C
@@ -5,23 +5,8 @@
 * Copyright (C) 1994-2003 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/spinmc_evaluate.C
+++ b/applications/mc/spins/spinmc_evaluate.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2004 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/spinmc_factory.C
+++ b/applications/mc/spins/spinmc_factory.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                       Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/spinsim.h
+++ b/applications/mc/spins/spinsim.h
@@ -5,23 +5,8 @@
 * Copyright (C) 1999-2003 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Fabian Stoeckli <fabstoec@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/tinyvec.h
+++ b/applications/mc/spins/tinyvec.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/mc/spins/xy.h
+++ b/applications/mc/spins/xy.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1999-2003 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/checksign/checksign.C
+++ b/applications/qmc/checksign/checksign.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/dwa/bandstructure.hpp
+++ b/applications/qmc/dwa/bandstructure.hpp
@@ -6,23 +6,8 @@
 *                       Lode Pollet      <pollet@phys.ethz.ch> ,
 *                       Ping Nang Ma     <pingnang@phys.ethz.ch> 
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/dwa/dwa.cpp
+++ b/applications/qmc/dwa/dwa.cpp
@@ -9,23 +9,8 @@
 *                       Lode Pollet      <pollet@phys.ethz.ch> ,
 *                       Ping Nang Ma     <tamama@yotcopi.com> 
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/dwa/dwa.hpp
+++ b/applications/qmc/dwa/dwa.hpp
@@ -7,23 +7,8 @@
 *                   Lode Pollet      <pollet@phys.ethz.ch> ,
 *                   Ping Nang Ma     <tamama@yotcopi.com> 
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/dwa/python/dwa.cpp
+++ b/applications/qmc/dwa/python/dwa.cpp
@@ -6,23 +6,8 @@
 *                       Lode Pollet      <pollet@phys.ethz.ch> ,
 *                       Ping Nang Ma     <pingnang@phys.ethz.ch> 
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/dwa/worldlines.hpp
+++ b/applications/qmc/dwa/worldlines.hpp
@@ -7,23 +7,8 @@
 *                       Lode Pollet      <pollet@phys.ethz.ch> ,
 *                       Ping Nang Ma     <tamama@phys.ethz.ch> 
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/loop.C
+++ b/applications/qmc/looper/loop.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/loop_config.h
+++ b/applications/qmc/looper/loop_config.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/loop_custom.C
+++ b/applications/qmc/looper/loop_custom.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/loop_model.C
+++ b/applications/qmc/looper/loop_model.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/alternating_tensor.h
+++ b/applications/qmc/looper/looper/alternating_tensor.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/cluster.h
+++ b/applications/qmc/looper/looper/cluster.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/correlation.h
+++ b/applications/qmc/looper/looper/correlation.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/crop.h
+++ b/applications/qmc/looper/looper/crop.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/custom.h
+++ b/applications/qmc/looper/looper/custom.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/custom_impl.h
+++ b/applications/qmc/looper/looper/custom_impl.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/divide_if_positive.h
+++ b/applications/qmc/looper/looper/divide_if_positive.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/evaluator.h
+++ b/applications/qmc/looper/looper/evaluator.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/evaluator_impl.h
+++ b/applications/qmc/looper/looper/evaluator_impl.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/graph.h
+++ b/applications/qmc/looper/looper/graph.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/graph_impl.h
+++ b/applications/qmc/looper/looper/graph_impl.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/integer_range.h
+++ b/applications/qmc/looper/looper/integer_range.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/lapack.h
+++ b/applications/qmc/looper/looper/lapack.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/lattice.h
+++ b/applications/qmc/looper/looper/lattice.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/location.h
+++ b/applications/qmc/looper/looper/location.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/location_impl.h
+++ b/applications/qmc/looper/looper/location_impl.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/matrix.h
+++ b/applications/qmc/looper/looper/matrix.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/measurement.h
+++ b/applications/qmc/looper/looper/measurement.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/model.h
+++ b/applications/qmc/looper/looper/model.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/model_impl.h
+++ b/applications/qmc/looper/looper/model_impl.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/model_parameter.h
+++ b/applications/qmc/looper/looper/model_parameter.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/montecarlo.h
+++ b/applications/qmc/looper/looper/montecarlo.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/operator.h
+++ b/applications/qmc/looper/looper/operator.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/permutation.h
+++ b/applications/qmc/looper/looper/permutation.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/power.h
+++ b/applications/qmc/looper/looper/power.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/random_choice.h
+++ b/applications/qmc/looper/looper/random_choice.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/stiffness.h
+++ b/applications/qmc/looper/looper/stiffness.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/susceptibility.h
+++ b/applications/qmc/looper/looper/susceptibility.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/temperature.h
+++ b/applications/qmc/looper/looper/temperature.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/time.h
+++ b/applications/qmc/looper/looper/time.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/type.h
+++ b/applications/qmc/looper/looper/type.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/union_find.h
+++ b/applications/qmc/looper/looper/union_find.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/version.h
+++ b/applications/qmc/looper/looper/version.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/weight.h
+++ b/applications/qmc/looper/looper/weight.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/looper/weight_impl.h
+++ b/applications/qmc/looper/looper/weight_impl.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/path_integral.C
+++ b/applications/qmc/looper/path_integral.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/looper/sse.C
+++ b/applications/qmc/looper/sse.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/qmc.h
+++ b/applications/qmc/qmc.h
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2006 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/qmc.ngs.h
+++ b/applications/qmc/qmc.ngs.h
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@comp-phys.org>,
 *                            Ping Nang Ma <pingnang@phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/qwl/qwl.C
+++ b/applications/qmc/qwl/qwl.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2004 by Stefan Wessel <wessel@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/qwl/qwl_evaluate.C
+++ b/applications/qmc/qwl/qwl_evaluate.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2004-2006 by Stefan Wessel <wessel@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/qwl/qwl_histogram.h
+++ b/applications/qmc/qwl/qwl_histogram.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2004 by Stefan Wessel <wessel@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/qwl/qwl_sse.h
+++ b/applications/qmc/qwl/qwl_sse.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2004-2005 by Stefan Wessel <wessel@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse/SSE.Classes.hpp
+++ b/applications/qmc/sse/SSE.Classes.hpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2003 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse/SSE.Directed.cpp
+++ b/applications/qmc/sse/SSE.Directed.cpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2006 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse/SSE.Initialization.cpp
+++ b/applications/qmc/sse/SSE.Initialization.cpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2006 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse/SSE.Measurements.cpp
+++ b/applications/qmc/sse/SSE.Measurements.cpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2005 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse/SSE.Update.cpp
+++ b/applications/qmc/sse/SSE.Update.cpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2006 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse/SSE.cpp
+++ b/applications/qmc/sse/SSE.cpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse/SSE.hpp
+++ b/applications/qmc/sse/SSE.hpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2009 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse/evaluate.C
+++ b/applications/qmc/sse/evaluate.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2002-2008 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse2/SSE.Classes.hpp
+++ b/applications/qmc/sse2/SSE.Classes.hpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2003 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse2/SSE.Directed.cpp
+++ b/applications/qmc/sse2/SSE.Directed.cpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2003 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse2/SSE.Histogram.hpp
+++ b/applications/qmc/sse2/SSE.Histogram.hpp
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2004 by Stefan Wessel <wessel@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse2/SSE.Initialization.cpp
+++ b/applications/qmc/sse2/SSE.Initialization.cpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2005 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse2/SSE.Measurements.cpp
+++ b/applications/qmc/sse2/SSE.Measurements.cpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2005 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse2/SSE.Update.cpp
+++ b/applications/qmc/sse2/SSE.Update.cpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2005 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse2/SSE.cpp
+++ b/applications/qmc/sse2/SSE.cpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse2/SSE.hpp
+++ b/applications/qmc/sse2/SSE.hpp
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2005 by Fabien Alet <alet@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse4/lattice.h
+++ b/applications/qmc/sse4/lattice.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2010 by Sergei Isakov <isakov@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse4/lp_sse.cpp
+++ b/applications/qmc/sse4/lp_sse.cpp
@@ -4,23 +4,8 @@
  *
  * Copyright (C) 2010 by Lode Pollet <pollet@itp.phys.ethz.ch>
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/qmc/sse4/lp_sse.h
+++ b/applications/qmc/sse4/lp_sse.h
@@ -4,23 +4,8 @@
  *
  * Copyright (C) 2010 by Lode Pollet <pollet@itp.phys.ethz.ch>
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/applications/qmc/sse4/measurement.h
+++ b/applications/qmc/sse4/measurement.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2010 by Sergei Isakov <isakov@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse4/model.h
+++ b/applications/qmc/sse4/model.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2010 by Sergei Isakov <isakov@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse4/sse.h
+++ b/applications/qmc/sse4/sse.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2009-2010 by Sergei Isakov <isakov@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse4/sse_alg.h
+++ b/applications/qmc/sse4/sse_alg.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2010 by Sergei Isakov <isakov@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse4/sse_alg_def.h
+++ b/applications/qmc/sse4/sse_alg_def.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2010 by Sergei Isakov <isakov@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/sse4/sse_worm_prob.h
+++ b/applications/qmc/sse4/sse_worm_prob.h
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 2003-2010 by Sergei Isakov <isakov@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/WKink.h
+++ b/applications/qmc/worms/WKink.h
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/WModel.C
+++ b/applications/qmc/worms/WModel.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/WRun.C
+++ b/applications/qmc/worms/WRun.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/WRun.h
+++ b/applications/qmc/worms/WRun.h
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/Wcheck.C
+++ b/applications/qmc/worms/Wcheck.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/Wdostep.C
+++ b/applications/qmc/worms/Wdostep.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/Winit.C
+++ b/applications/qmc/worms/Winit.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/Wmeas.C
+++ b/applications/qmc/worms/Wmeas.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/cyclic_iterator.h
+++ b/applications/qmc/worms/cyclic_iterator.h
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/evaluate.C
+++ b/applications/qmc/worms/evaluate.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2002-2003 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/main.C
+++ b/applications/qmc/worms/main.C
@@ -5,23 +5,8 @@
 * Copyright (C) 2002-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/random.h
+++ b/applications/qmc/worms/random.h
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/applications/qmc/worms/time_struct.h
+++ b/applications/qmc/worms/time_struct.h
@@ -5,23 +5,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Simon Trebst <trebst@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/alea/example_autocorrelation.cpp
+++ b/example/alea/example_autocorrelation.cpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/alea/example_autocorrelation.py
+++ b/example/alea/example_autocorrelation.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 #*                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 #*                            Maximilian Poprawe <poprawem@ethz.ch>
 #*
-#* This software is part of the ALPS libraries, published under the ALPS
-#* Library License; you can use, redistribute it and/or modify it under
-#* the terms of the license, either version 1 or (at your option) any later
-#* version.
-#*
-#* You should have received a copy of the ALPS Library License along with
-#* the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-#* available from http://alps.comp-phys.org/.
-#*
-#* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-#* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-#* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-#* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#* DEALINGS IN THE SOFTWARE.
+#* ALPS Project: https://alps.comp-phys.org/
+#* SPDX-License-Identifier: MIT
 #*
 #*****************************************************************************/
 

--- a/example/alea/example_error.cpp
+++ b/example/alea/example_error.cpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/alea/example_error.py
+++ b/example/alea/example_error.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 #*                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 #*                            Maximilian Poprawe <poprawem@ethz.ch>
 #*
-#* This software is part of the ALPS libraries, published under the ALPS
-#* Library License; you can use, redistribute it and/or modify it under
-#* the terms of the license, either version 1 or (at your option) any later
-#* version.
-#*
-#* You should have received a copy of the ALPS Library License along with
-#* the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-#* available from http://alps.comp-phys.org/.
-#*
-#* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-#* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-#* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-#* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#* DEALINGS IN THE SOFTWARE.
+#* ALPS Project: https://alps.comp-phys.org/
+#* SPDX-License-Identifier: MIT
 #*
 #*****************************************************************************/
 

--- a/example/alea/example_mean.cpp
+++ b/example/alea/example_mean.cpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/alea/example_mean.py
+++ b/example/alea/example_mean.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 #*                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 #*                            Maximilian Poprawe <poprawem@ethz.ch>
 #*
-#* This software is part of the ALPS libraries, published under the ALPS
-#* Library License; you can use, redistribute it and/or modify it under
-#* the terms of the license, either version 1 or (at your option) any later
-#* version.
-#*
-#* You should have received a copy of the ALPS Library License along with
-#* the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-#* available from http://alps.comp-phys.org/.
-#*
-#* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-#* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-#* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-#* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#* DEALINGS IN THE SOFTWARE.
+#* ALPS Project: https://alps.comp-phys.org/
+#* SPDX-License-Identifier: MIT
 #*
 #*****************************************************************************/
 

--- a/example/alea/example_running_mean.cpp
+++ b/example/alea/example_running_mean.cpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/alea/example_running_mean.py
+++ b/example/alea/example_running_mean.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 #*                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 #*                            Maximilian Poprawe <poprawem@ethz.ch>
 #*
-#* This software is part of the ALPS libraries, published under the ALPS
-#* Library License; you can use, redistribute it and/or modify it under
-#* the terms of the license, either version 1 or (at your option) any later
-#* version.
-#*
-#* You should have received a copy of the ALPS Library License along with
-#* the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-#* available from http://alps.comp-phys.org/.
-#*
-#* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-#* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-#* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-#* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#* DEALINGS IN THE SOFTWARE.
+#* ALPS Project: https://alps.comp-phys.org/
+#* SPDX-License-Identifier: MIT
 #*
 #*****************************************************************************/
 

--- a/example/alea/example_variance.cpp
+++ b/example/alea/example_variance.cpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/alea/example_variance.py
+++ b/example/alea/example_variance.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 #*                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 #*                            Maximilian Poprawe <poprawem@ethz.ch>
 #*
-#* This software is part of the ALPS libraries, published under the ALPS
-#* Library License; you can use, redistribute it and/or modify it under
-#* the terms of the license, either version 1 or (at your option) any later
-#* version.
-#*
-#* You should have received a copy of the ALPS Library License along with
-#* the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-#* available from http://alps.comp-phys.org/.
-#*
-#* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-#* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-#* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-#* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#* DEALINGS IN THE SOFTWARE.
+#* ALPS Project: https://alps.comp-phys.org/
+#* SPDX-License-Identifier: MIT
 #*
 #*****************************************************************************/
 

--- a/example/fortran/hello/hello_impl.f90
+++ b/example/fortran/hello/hello_impl.f90
@@ -6,22 +6,8 @@
 !
 ! Copyright (C) 2011 by Synge Todo <wistaria@comp-phys.org>
 !
-! This software is part of the ALPS libraries, published under the ALPS
-! Library License; you can use, redistribute it and/or modify it under
-! the terms of the license, either version 1 or (at your option) any later
-! version.
-! 
-! You should have received a copy of the ALPS Library License along with
-! the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-! available from http://alps.comp-phys.org/.
-!
-! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-! FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-! SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-! FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-! ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-! DEALINGS IN THE SOFTWARE.
+! ALPS Project: https://alps.comp-phys.org/
+! SPDX-License-Identifier: MIT
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/example/fortran/hello/main.C
+++ b/example/fortran/hello/main.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/fortran/ising/ising_impl.f90
+++ b/example/fortran/ising/ising_impl.f90
@@ -6,22 +6,8 @@
 !
 ! Copyright (C) 2011 by Synge Todo <wistaria@comp-phys.org>
 !
-! This software is part of the ALPS libraries, published under the ALPS
-! Library License; you can use, redistribute it and/or modify it under
-! the terms of the license, either version 1 or (at your option) any later
-! version.
-! 
-! You should have received a copy of the ALPS Library License along with
-! the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-! available from http://alps.comp-phys.org/.
-!
-! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-! FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-! SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-! FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-! ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-! DEALINGS IN THE SOFTWARE.
+! ALPS Project: https://alps.comp-phys.org/
+! SPDX-License-Identifier: MIT
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/example/fortran/ising/main.C
+++ b/example/fortran/ising/main.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/hdf5/enum_as_class.cpp
+++ b/example/hdf5/enum_as_class.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/hdf5/enum_vectorizable.cpp
+++ b/example/hdf5/enum_vectorizable.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/hdf5/pair_int_vectorizable.cpp
+++ b/example/hdf5/pair_int_vectorizable.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/ietl/arnoldi1.h
+++ b/example/ietl/arnoldi1.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Bela Bauer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/ietl/arnoldi1_complex.cpp
+++ b/example/ietl/arnoldi1_complex.cpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Bela Bauer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/ietl/arnoldi1_real.cpp
+++ b/example/ietl/arnoldi1_real.cpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Bela Bauer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/model/matrix.h
+++ b/example/model/matrix.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/model/print_numeric.cpp
+++ b/example/model/print_numeric.cpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/model/print_numeric2.cpp
+++ b/example/model/print_numeric2.cpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/model/print_numeric3.cpp
+++ b/example/model/print_numeric3.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *               2010-2010 by Ryo IGARASHI <rigarash@hosi.phys.s.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/model/print_symbolic.cpp
+++ b/example/model/print_symbolic.cpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/model/print_symbolic2.cpp
+++ b/example/model/print_symbolic2.cpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/model/print_symbolic3.cpp
+++ b/example/model/print_symbolic3.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *               2010-2010 by Ryo IGARASHI <rigarash@hosi.phys.s.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/ngs/alea/custom_accum.hpp
+++ b/example/ngs/alea/custom_accum.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/ngs/alea/example_accumulator.cpp
+++ b/example/ngs/alea/example_accumulator.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/ngs/alea/example_accumulator_set.cpp
+++ b/example/ngs/alea/example_accumulator_set.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/ngs/alea/example_custom_accum.cpp
+++ b/example/ngs/alea/example_custom_accum.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/ngs/alea/example_histogram.cpp
+++ b/example/ngs/alea/example_histogram.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/ngs/alea/example_new_input_op.cpp
+++ b/example/ngs/alea/example_new_input_op.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/ngs/alea/example_vector_operators.cpp
+++ b/example/ngs/alea/example_vector_operators.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/ngs/alea/test_alps_multi_array.cpp
+++ b/example/ngs/alea/test_alps_multi_array.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/example/parapack/exchange/ising.C
+++ b/example/parapack/exchange/ising.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/exchange/loop.C
+++ b/example/parapack/exchange/loop.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/exchange/main.C
+++ b/example/parapack/exchange/main.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/heisenberg/heisenberg.C
+++ b/example/parapack/heisenberg/heisenberg.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2012 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/heisenberg/heisenberg.h
+++ b/example/parapack/heisenberg/heisenberg.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2012 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/ising/ising.C
+++ b/example/parapack/ising/ising.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/ising/ising.h
+++ b/example/parapack/ising/ising.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2012 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/loop/loop.C
+++ b/example/parapack/loop/loop.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/loop/loop.h
+++ b/example/parapack/loop/loop.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/loop/main.C
+++ b/example/parapack/loop/main.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/loop/union_find.h
+++ b/example/parapack/loop/union_find.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/multiple/ising.C
+++ b/example/parapack/multiple/ising.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/multiple/ising.h
+++ b/example/parapack/multiple/ising.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/multiple/main.C
+++ b/example/parapack/multiple/main.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/single/ising.C
+++ b/example/parapack/single/ising.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/single/ising.h
+++ b/example/parapack/single/ising.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/single/main.C
+++ b/example/parapack/single/main.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/wanglandau/main.C
+++ b/example/parapack/wanglandau/main.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/wanglandau/wanglandau.C
+++ b/example/parapack/wanglandau/wanglandau.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/parapack/wanglandau/wanglandau.h
+++ b/example/parapack/wanglandau/wanglandau.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/sampling/fleas.h
+++ b/example/sampling/fleas.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2007 - 2010 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/sampling/fleas_correlated.C
+++ b/example/sampling/fleas_correlated.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2007 - 2010 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/sampling/fleas_direct.C
+++ b/example/sampling/fleas_direct.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2007 - 2010 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/sampling/fleas_independent.C
+++ b/example/sampling/fleas_independent.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2007 - 2010 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/sampling/fleas_simpleminded.C
+++ b/example/sampling/fleas_simpleminded.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2007 - 2010 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/sampling/fleas_uncorrelated.C
+++ b/example/sampling/fleas_uncorrelated.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2007 - 2010 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/scheduler/evaluate.C
+++ b/example/scheduler/evaluate.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/scheduler/evaluate2.C
+++ b/example/scheduler/evaluate2.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/scheduler/ising.C
+++ b/example/scheduler/ising.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/scheduler/ising.h
+++ b/example/scheduler/ising.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/scheduler/ising2.C
+++ b/example/scheduler/ising2.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/scheduler/ising2.h
+++ b/example/scheduler/ising2.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/scheduler/main.C
+++ b/example/scheduler/main.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/scheduler/main2.C
+++ b/example/scheduler/main2.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/example/scheduler/main3.C
+++ b/example/scheduler/main3.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/lib/mpi.py
+++ b/lib/mpi.py
@@ -6,23 +6,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # Permission is hereby granted, free of charge, to any person obtaining           #
- # a copy of this software and associated documentation files (the “Software”),    #
- # to deal in the Software without restriction, including without limitation       #
- # the rights to use, copy, modify, merge, publish, distribute, sublicense,        #
- # and/or sell copies of the Software, and to permit persons to whom the           #
- # Software is furnished to do so, subject to the following conditions:            #
- #                                                                                 #
- # The above copyright notice and this permission notice shall be included         #
- # in all copies or substantial portions of the Software.                          #
- #                                                                                 #
- # THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         #
- # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     #
- # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     #
- # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          #
- # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         #
- # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  #                                                                                 #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/lib/pyalps/__init__.py
+++ b/lib/pyalps/__init__.py
@@ -7,23 +7,8 @@ from __future__ import absolute_import
 # 
 # Copyright (C) 1994-2009 by Bela Bauer <bauerb@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/alea.py
+++ b/lib/pyalps/alea.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 2010 by Olivier Parcollet
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/alea_detail.py
+++ b/lib/pyalps/alea_detail.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 2010 by Olivier Parcollet
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/apptest.py
+++ b/lib/pyalps/apptest.py
@@ -7,23 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2012 by Sebastian Keller
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/cxx.py
+++ b/lib/pyalps/cxx.py
@@ -7,23 +7,8 @@ from __future__ import absolute_import
 #
 # Copyright (C) 2016 by Michele Dolfi <dolfim@phys.ethz.ch>
 #
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 #
 # ****************************************************************************
 

--- a/lib/pyalps/dataset.py
+++ b/lib/pyalps/dataset.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 1994-2009 by Bela Bauer <bauerb@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/dict_intersect.py
+++ b/lib/pyalps/dict_intersect.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 1994-2009 by Bela Bauer <bauerb@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/dwa.py
+++ b/lib/pyalps/dwa.py
@@ -8,23 +8,8 @@ from __future__ import absolute_import
 #
 # Copyright (C) 2013 by Tama Ma <pingnang@phys.ethz.ch>
 #
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 #
 # ****************************************************************************
 

--- a/lib/pyalps/fit_wrapper.py
+++ b/lib/pyalps/fit_wrapper.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 1994-2009 by Bela Bauer <bauerb@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/floatwitherror.py
+++ b/lib/pyalps/floatwitherror.py
@@ -7,23 +7,8 @@ from __future__ import absolute_import
 # 
 # Copyright (C) 2009 by Ping Nang (Tama) Ma <pingnang@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 from sys  import stdin

--- a/lib/pyalps/hdf5.py
+++ b/lib/pyalps/hdf5.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 2010 by Olivier Parcollet
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/hlist.py
+++ b/lib/pyalps/hlist.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 1994-2009 by Bela Bauer <bauerb@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/load.py
+++ b/lib/pyalps/load.py
@@ -9,23 +9,8 @@ from __future__ import absolute_import
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch>
 #                            Brigitte Surer <surerb@phys.ethz.ch> 
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/math.py
+++ b/lib/pyalps/math.py
@@ -7,23 +7,8 @@
 # Copyright (C) 1994-2010 by Bela Bauer <bauerb@phys.ethz.ch>
 #                            Ping Nang Ma
 #
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/maxent.py
+++ b/lib/pyalps/maxent.py
@@ -6,23 +6,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Matthias Troyer <gamperl@gmail.com>                #
  #                                                                                 #
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
  #                                                                                 #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/lib/pyalps/mpi.py
+++ b/lib/pyalps/mpi.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 2012 by Matthias Troyer
 #
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/mpl_setup_macosx.py
+++ b/lib/pyalps/mpl_setup_macosx.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/mpl_setup_qt.py
+++ b/lib/pyalps/mpl_setup_qt.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/mpl_setup_tk.py
+++ b/lib/pyalps/mpl_setup_tk.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/ngs.py
+++ b/lib/pyalps/ngs.py
@@ -7,23 +7,8 @@
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                      2012 by Troels F. Roennow <tfr@nanophysics.dk>             #
  #                                                                                 #
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
  #                                                                                 #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/lib/pyalps/plot.py
+++ b/lib/pyalps/plot.py
@@ -9,23 +9,8 @@ from __future__ import absolute_import
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch>
 # Copyright (C) 2012-2012 by Michele Dolfi <dolfim@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/plot_core.py
+++ b/lib/pyalps/plot_core.py
@@ -8,23 +8,8 @@ from __future__ import absolute_import
 # Copyright (C) 1994-2010 by Bela Bauer <bauerb@phys.ethz.ch>
 #                            Brigitte Surer <surerb@phys.ethz.ch>
 #
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/pytools.py
+++ b/lib/pyalps/pytools.py
@@ -6,23 +6,8 @@
 # 
 # Copyright (C) 2010 by Olivier Parcollet
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/lib/pyalps/tools.py
+++ b/lib/pyalps/tools.py
@@ -7,23 +7,8 @@ from __future__ import absolute_import
 # 
 # Copyright (C) 2010 by Bela Bauer <bauerb@phys.ethz.ch>
 # 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the “Software”),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 import os

--- a/script/compile.py
+++ b/script/compile.py
@@ -7,22 +7,8 @@
 # 
 # Copyright (C) 2010 by Matthias Troyer
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/src/alps/alea.h
+++ b/src/alps/alea.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2004 by Synge Todo <wistaria@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/abstractbinning.h
+++ b/src/alps/alea/abstractbinning.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/abstractsimpleobservable.h
+++ b/src/alps/alea/abstractsimpleobservable.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/abstractsimpleobservable.ipp
+++ b/src/alps/alea/abstractsimpleobservable.ipp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/convergence.hpp
+++ b/src/alps/alea/convergence.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/detailedbinning.h
+++ b/src/alps/alea/detailedbinning.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/histogram.h
+++ b/src/alps/alea/histogram.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1997-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/histogramdata.h
+++ b/src/alps/alea/histogramdata.h
@@ -8,23 +8,8 @@
 *                            Fabian Stoeckli <fabstoec@phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/histogrameval.h
+++ b/src/alps/alea/histogrameval.h
@@ -8,23 +8,8 @@
 *                            Fabian Stoeckli <fabstoec@phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/mcanalyze.hpp
+++ b/src/alps/alea/mcanalyze.hpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/mcdata.hpp
+++ b/src/alps/alea/mcdata.hpp
@@ -13,23 +13,8 @@
 *                            Lukas Gamper <gamperl@gmail.com>,
 *                            Jan Gukelberger <gukelberger@phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/nan.C
+++ b/src/alps/alea/nan.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/nan.h
+++ b/src/alps/alea/nan.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/nobinning.h
+++ b/src/alps/alea/nobinning.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/observable.C
+++ b/src/alps/alea/observable.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2008 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/observable.h
+++ b/src/alps/alea/observable.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/observable_fwd.hpp
+++ b/src/alps/alea/observable_fwd.hpp
@@ -10,23 +10,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>
 *                            Lukas Gamper <gamperl@gmail.com>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/observablefactory.C
+++ b/src/alps/alea/observablefactory.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/observablefactory.h
+++ b/src/alps/alea/observablefactory.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/observableset.C
+++ b/src/alps/alea/observableset.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2012 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/observableset.h
+++ b/src/alps/alea/observableset.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/observableset_p.h
+++ b/src/alps/alea/observableset_p.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/output_helper.h
+++ b/src/alps/alea/output_helper.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/recordableobservable.h
+++ b/src/alps/alea/recordableobservable.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/signedobservable.h
+++ b/src/alps/alea/signedobservable.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2012 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/simplebinning.h
+++ b/src/alps/alea/simplebinning.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/simpleobsdata.h
+++ b/src/alps/alea/simpleobsdata.h
@@ -10,23 +10,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Andreas Lange <alange@phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/simpleobservable.h
+++ b/src/alps/alea/simpleobservable.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/simpleobservable.ipp
+++ b/src/alps/alea/simpleobservable.ipp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/simpleobseval.h
+++ b/src/alps/alea/simpleobseval.h
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/simpleobseval.ipp
+++ b/src/alps/alea/simpleobseval.ipp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/type_tag.hpp
+++ b/src/alps/alea/type_tag.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/alea/value_with_error.hpp
+++ b/src/alps/alea/value_with_error.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/cctype.h
+++ b/src/alps/cctype.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/check_schedule.hpp
+++ b/src/alps/check_schedule.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2012 by Jan Gukelberger <gukel@comp-phys.org>                     *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/config.h.in
+++ b/src/alps/config.h.in
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression.h
+++ b/src/alps/expression.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/block.h
+++ b/src/alps/expression/block.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/evaluatable.h
+++ b/src/alps/expression/evaluatable.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/evaluate.h
+++ b/src/alps/expression/evaluate.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/evaluate_helper.h
+++ b/src/alps/expression/evaluate_helper.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/evaluator.C
+++ b/src/alps/expression/evaluator.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/evaluator.h
+++ b/src/alps/expression/evaluator.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/expression.h
+++ b/src/alps/expression/expression.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/expression_fwd.h
+++ b/src/alps/expression/expression_fwd.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/factor.h
+++ b/src/alps/expression/factor.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/function.h
+++ b/src/alps/expression/function.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/number.h
+++ b/src/alps/expression/number.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/parameterevaluator.h
+++ b/src/alps/expression/parameterevaluator.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/symbol.h
+++ b/src/alps/expression/symbol.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/term.h
+++ b/src/alps/expression/term.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/expression/traits.h
+++ b/src/alps/expression/traits.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/factory.h
+++ b/src/alps/factory.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fixed_capacity/checking.h
+++ b/src/alps/fixed_capacity/checking.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fixed_capacity/deque_detail.h
+++ b/src/alps/fixed_capacity/deque_detail.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fixed_capacity/uninitialized_array.h
+++ b/src/alps/fixed_capacity/uninitialized_array.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fixed_capacity_deque.h
+++ b/src/alps/fixed_capacity_deque.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fixed_capacity_fwd.h
+++ b/src/alps/fixed_capacity_fwd.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fixed_capacity_traits.h
+++ b/src/alps/fixed_capacity_traits.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fixed_capacity_vector.h
+++ b/src/alps/fixed_capacity_vector.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fortran/alps_fortran.h
+++ b/src/alps/fortran/alps_fortran.h
@@ -6,23 +6,8 @@
 !
 ! Copyright (C) 2011 by Synge Todo <wistaria@comp-phys.org>
 !
-! Permission is hereby granted, free of charge, to any person obtaining
-! a copy of this software and associated documentation files (the “Software”),
-! to deal in the Software without restriction, including without limitation
-! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-! and/or sell copies of the Software, and to permit persons to whom the
-! Software is furnished to do so, subject to the following conditions:
-!
-! The above copyright notice and this permission notice shall be included
-! in all copies or substantial portions of the Software.
-!
-! THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-! DEALINGS IN THE SOFTWARE.
+! ALPS Project: https://alps.comp-phys.org/
+! SPDX-License-Identifier: MIT
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/alps/fortran/fortran_wrapper.h
+++ b/src/alps/fortran/fortran_wrapper.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fortran/fwrapper_impl.C
+++ b/src/alps/fortran/fwrapper_impl.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/fortran/fwrapper_impl.h
+++ b/src/alps/fortran/fwrapper_impl.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/functional.h
+++ b/src/alps/functional.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/graph/canonical_graph.hpp
+++ b/src/alps/graph/canonical_graph.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/graph/canonical_properties.hpp
+++ b/src/alps/graph/canonical_properties.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2015 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/graph/canonical_properties_traits.hpp
+++ b/src/alps/graph/canonical_properties_traits.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_GRAPH_CANONICAL_PROPERTIES_TRAITS_HPP

--- a/src/alps/graph/detail/assert_helpers.hpp
+++ b/src/alps/graph/detail/assert_helpers.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2014        by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_GRAPH_DETAIL_ASSERT_HELPERS_HPP

--- a/src/alps/graph/detail/canonical_properties_impl.hpp
+++ b/src/alps/graph/detail/canonical_properties_impl.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2015 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/graph/detail/helper_functions.hpp
+++ b/src/alps/graph/detail/helper_functions.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2015 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/graph/detail/lattice_constant_impl.hpp
+++ b/src/alps/graph/detail/lattice_constant_impl.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2015 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/graph/detail/shared_queue.hpp
+++ b/src/alps/graph/detail/shared_queue.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2015        by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_GRAPH_DETAIL_SHARED_QUEUE_HPP

--- a/src/alps/graph/is_embeddable.hpp
+++ b/src/alps/graph/is_embeddable.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_GRAPH_IS_EMBEDDABLE_HPP

--- a/src/alps/graph/lattice_constant.hpp
+++ b/src/alps/graph/lattice_constant.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/graph/lattice_constant_debug.hpp
+++ b/src/alps/graph/lattice_constant_debug.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/graph/subgraph_generator.hpp
+++ b/src/alps/graph/subgraph_generator.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2013 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/graph/subgraphs.hpp
+++ b/src/alps/graph/subgraphs.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/graph/utils.hpp
+++ b/src/alps/graph/utils.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5.hpp
+++ b/src/alps/hdf5.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/archive.cpp
+++ b/src/alps/hdf5/archive.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/archive.hpp
+++ b/src/alps/hdf5/archive.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/array.hpp
+++ b/src/alps/hdf5/array.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/complex.hpp
+++ b/src/alps/hdf5/complex.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/errors.hpp
+++ b/src/alps/hdf5/errors.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/map.hpp
+++ b/src/alps/hdf5/map.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/matrix.hpp
+++ b/src/alps/hdf5/matrix.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2012 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/multi_array.hpp
+++ b/src/alps/hdf5/multi_array.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/numeric_vector.hpp
+++ b/src/alps/hdf5/numeric_vector.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/pair.hpp
+++ b/src/alps/hdf5/pair.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/pointer.hpp
+++ b/src/alps/hdf5/pointer.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/python.cpp
+++ b/src/alps/hdf5/python.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/python.hpp
+++ b/src/alps/hdf5/python.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/shared_array.hpp
+++ b/src/alps/hdf5/shared_array.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/stdarray.hpp
+++ b/src/alps/hdf5/stdarray.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/tuple.hpp
+++ b/src/alps/hdf5/tuple.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/ublas/matrix.hpp
+++ b/src/alps/hdf5/ublas/matrix.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/ublas/vector.hpp
+++ b/src/alps/hdf5/ublas/vector.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/valarray.hpp
+++ b/src/alps/hdf5/valarray.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/hdf5/vector.hpp
+++ b/src/alps/hdf5/vector.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/lambda.hpp
+++ b/src/alps/lambda.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice.h
+++ b/src/alps/lattice.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003 by Synge Todo <wistaria@comp-phys.org>,
 *                       and Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/bond_compare.h
+++ b/src/alps/lattice/bond_compare.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2004 by Ian McCulloch <ianmcc@physik.rwth-aachen.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/boundary.h
+++ b/src/alps/lattice/boundary.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/cell_traits.h
+++ b/src/alps/lattice/cell_traits.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2002 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/coordinate_traits.h
+++ b/src/alps/lattice/coordinate_traits.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2002 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/coordinategraph.h
+++ b/src/alps/lattice/coordinategraph.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/coordinatelattice.h
+++ b/src/alps/lattice/coordinatelattice.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/dimensional_traits.h
+++ b/src/alps/lattice/dimensional_traits.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/disorder.C
+++ b/src/alps/lattice/disorder.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/disorder.h
+++ b/src/alps/lattice/disorder.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@comp-phys.orgh>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/graph.h
+++ b/src/alps/lattice/graph.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/graph_helper.h
+++ b/src/alps/lattice/graph_helper.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2000-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/graph_traits.h
+++ b/src/alps/lattice/graph_traits.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/graphproperties.h
+++ b/src/alps/lattice/graphproperties.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/hypercubic.h
+++ b/src/alps/lattice/hypercubic.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/lattice.h
+++ b/src/alps/lattice/lattice.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/latticedescriptor.C
+++ b/src/alps/lattice/latticedescriptor.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/latticedescriptor.h
+++ b/src/alps/lattice/latticedescriptor.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/latticegraph.h
+++ b/src/alps/lattice/latticegraph.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/latticegraphdescriptor.C
+++ b/src/alps/lattice/latticegraphdescriptor.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/latticegraphdescriptor.h
+++ b/src/alps/lattice/latticegraphdescriptor.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@comp-phys.orgh>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/latticelibrary.C
+++ b/src/alps/lattice/latticelibrary.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/latticelibrary.h
+++ b/src/alps/lattice/latticelibrary.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/parity.h
+++ b/src/alps/lattice/parity.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/point_traits.h
+++ b/src/alps/lattice/point_traits.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/propertymap.h
+++ b/src/alps/lattice/propertymap.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/simplecell.h
+++ b/src/alps/lattice/simplecell.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2002 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/simplelattice.h
+++ b/src/alps/lattice/simplelattice.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/unitcell.C
+++ b/src/alps/lattice/unitcell.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/lattice/unitcell.h
+++ b/src/alps/lattice/unitcell.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/mcbase.cpp
+++ b/src/alps/mcbase.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/mcbase.hpp
+++ b/src/alps/mcbase.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/mcmpiadapter.hpp
+++ b/src/alps/mcmpiadapter.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/model.h
+++ b/src/alps/model.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2005 by Synge Todo <wistaria@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/basisdescriptor.h
+++ b/src/alps/model/basisdescriptor.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/basisstates.h
+++ b/src/alps/model/basisstates.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2008 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/blochbasisstates.h
+++ b/src/alps/model/blochbasisstates.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/bondoperator.h
+++ b/src/alps/model/bondoperator.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/bondterm.C
+++ b/src/alps/model/bondterm.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/bondterm.h
+++ b/src/alps/model/bondterm.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/default_term.h
+++ b/src/alps/model/default_term.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/globaloperator.C
+++ b/src/alps/model/globaloperator.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/globaloperator.h
+++ b/src/alps/model/globaloperator.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/half_integer.h
+++ b/src/alps/model/half_integer.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/hamiltonian.h
+++ b/src/alps/model/hamiltonian.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/hamiltonian_matrix.hpp
+++ b/src/alps/model/hamiltonian_matrix.hpp
@@ -6,23 +6,8 @@
 *                            Andreas Honecker <ahoneck@uni-goettingen.de>,
 *                            Ryo IGARASHI <rigarash@hosi.phys.s.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/integer_state.h
+++ b/src/alps/model/integer_state.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/model_helper.h
+++ b/src/alps/model/model_helper.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/modellibrary.C
+++ b/src/alps/model/modellibrary.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/modellibrary.h
+++ b/src/alps/model/modellibrary.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/operator.h
+++ b/src/alps/model/operator.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/operatordescriptor.h
+++ b/src/alps/model/operatordescriptor.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/operatorsubstitution.h
+++ b/src/alps/model/operatorsubstitution.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2005 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/quantumnumber.h
+++ b/src/alps/model/quantumnumber.h
@@ -8,23 +8,8 @@
 *                            Axel Grzesik <axel@th.physik.uni-bonn.de>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/sign.h
+++ b/src/alps/model/sign.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/sitebasisdescriptor.h
+++ b/src/alps/model/sitebasisdescriptor.h
@@ -8,23 +8,8 @@
 *                            Axel Grzesik <axel@th.physik.uni-bonn.de>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/sitebasisstates.h
+++ b/src/alps/model/sitebasisstates.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Axel Grzesik <axel@th.physik.uni-bonn.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/siteoperator.h
+++ b/src/alps/model/siteoperator.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/sitestate.h
+++ b/src/alps/model/sitestate.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/siteterm.C
+++ b/src/alps/model/siteterm.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/siteterm.h
+++ b/src/alps/model/siteterm.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/model/substitute.h
+++ b/src/alps/model/substitute.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/multi_array.hpp
+++ b/src/alps/multi_array.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2012 by Ilia Zintchenko <iliazin@gmail.com>                       *
  *                       Jan Gukelberger                                           *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/multi_array/functions.hpp
+++ b/src/alps/multi_array/functions.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2012 by Ilia Zintchenko <iliazin@gmail.com>                       *
  *                       Jan Gukelberger                                           *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/multi_array/io.hpp
+++ b/src/alps/multi_array/io.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2012 by Ilia Zintchenko <iliazin@gmail.com>                       *
  *                       Jan Gukelberger                                           *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/multi_array/multi_array.hpp
+++ b/src/alps/multi_array/multi_array.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2012 by Ilia Zintchenko <iliazin@gmail.com>                       *
  *                       Jan Gukelberger                                           *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/multi_array/operators.hpp
+++ b/src/alps/multi_array/operators.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2012 by Ilia Zintchenko <iliazin@gmail.com>                       *
  *                       Jan Gukelberger                                           *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/multi_array/serialization.hpp
+++ b/src/alps/multi_array/serialization.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2012 by Ilia Zintchenko <iliazin@gmail.com>                       *
  *                       Jan Gukelberger                                           *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs.hpp
+++ b/src/alps/ngs.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                           Matthias Troyer <troyer@comp-phys.org>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator.hpp
+++ b/src/alps/ngs/accumulator.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/accumulator.cpp
+++ b/src/alps/ngs/accumulator/accumulator.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/accumulator.hpp
+++ b/src/alps/ngs/accumulator/accumulator.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/accumulator.hpp
+++ b/src/alps/ngs/accumulator/deprecated/accumulator.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/accumulator/accumulator_impl.hpp
+++ b/src/alps/ngs/accumulator/deprecated/accumulator/accumulator_impl.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/accumulator/arguments.hpp
+++ b/src/alps/ngs/accumulator/deprecated/accumulator/arguments.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/accumulator_set.hpp
+++ b/src/alps/ngs/accumulator/deprecated/accumulator_set.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/alea.hpp
+++ b/src/alps/ngs/accumulator/deprecated/alea.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/alea/accumulator_set.cpp
+++ b/src/alps/ngs/accumulator/deprecated/alea/accumulator_set.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #include <alps/ngs/alea/accumulator_set.hpp>

--- a/src/alps/ngs/accumulator/deprecated/alea/result_set.cpp
+++ b/src/alps/ngs/accumulator/deprecated/alea/result_set.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #include <alps/ngs/alea/result_set.hpp>

--- a/src/alps/ngs/accumulator/deprecated/feature/autocorrelation.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/autocorrelation.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/converged.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/converged.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
  

--- a/src/alps/ngs/accumulator/deprecated/feature/error.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/error.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/feature_traits.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/feature_traits.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/features.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/features.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/fixed_size_binning.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/fixed_size_binning.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/generate_property.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/generate_property.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/histogram.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/histogram.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
  

--- a/src/alps/ngs/accumulator/deprecated/feature/log_binning.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/log_binning.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/max_num_binning.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/max_num_binning.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/mean.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/mean.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/tags.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/tags.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/tau.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/tau.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/value_type.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/value_type.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/feature/weight.hpp
+++ b/src/alps/ngs/accumulator/deprecated/feature/weight.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/features.hpp
+++ b/src/alps/ngs/accumulator/deprecated/features.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/result.hpp
+++ b/src/alps/ngs/accumulator/deprecated/result.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Lukas Gamper <gamperl@gmail.ch>                           *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/result_set.hpp
+++ b/src/alps/ngs/accumulator/deprecated/result_set.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Lukas Gamper <gamperl@gmail.ch>                           *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/wrapper/accumulator_wrapper.hpp
+++ b/src/alps/ngs/accumulator/deprecated/wrapper/accumulator_wrapper.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/wrapper/base_wrapper.hpp
+++ b/src/alps/ngs/accumulator/deprecated/wrapper/base_wrapper.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/wrapper/derived_wrapper.hpp
+++ b/src/alps/ngs/accumulator/deprecated/wrapper/derived_wrapper.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/wrapper/result_type_wrapper.hpp
+++ b/src/alps/ngs/accumulator/deprecated/wrapper/result_type_wrapper.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/deprecated/wrapper/result_wrapper.hpp
+++ b/src/alps/ngs/accumulator/deprecated/wrapper/result_wrapper.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Lukas Gamper <gamperl@gmail.ch>                           *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/feature.hpp
+++ b/src/alps/ngs/accumulator/feature.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/feature/binning_analysis.hpp
+++ b/src/alps/ngs/accumulator/feature/binning_analysis.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/feature/count.hpp
+++ b/src/alps/ngs/accumulator/feature/count.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/feature/error.hpp
+++ b/src/alps/ngs/accumulator/feature/error.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/feature/max_num_binning.hpp
+++ b/src/alps/ngs/accumulator/feature/max_num_binning.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/feature/mean.hpp
+++ b/src/alps/ngs/accumulator/feature/mean.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/feature/weight.hpp
+++ b/src/alps/ngs/accumulator/feature/weight.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/feature/weight_holder.hpp
+++ b/src/alps/ngs/accumulator/feature/weight_holder.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/parameter.hpp
+++ b/src/alps/ngs/accumulator/parameter.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/accumulator/wrappers.hpp
+++ b/src/alps/ngs/accumulator/wrappers.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/api.hpp
+++ b/src/alps/ngs/api.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/boost_mpi.hpp
+++ b/src/alps/ngs/boost_mpi.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/boost_python.hpp
+++ b/src/alps/ngs/boost_python.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/cast.hpp
+++ b/src/alps/ngs/cast.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/config.hpp
+++ b/src/alps/ngs/config.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/export_sim_to_python.hpp
+++ b/src/alps/ngs/detail/export_sim_to_python.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/extract_from_pyobject.hpp
+++ b/src/alps/ngs/detail/extract_from_pyobject.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/get_numpy_type.hpp
+++ b/src/alps/ngs/detail/get_numpy_type.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/paramiterator.hpp
+++ b/src/alps/ngs/detail/paramiterator.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/paramproxy.hpp
+++ b/src/alps/ngs/detail/paramproxy.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/params_impl_base.hpp
+++ b/src/alps/ngs/detail/params_impl_base.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/paramvalue.hpp
+++ b/src/alps/ngs/detail/paramvalue.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/paramvalue_reader.hpp
+++ b/src/alps/ngs/detail/paramvalue_reader.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/remove_cvr.hpp
+++ b/src/alps/ngs/detail/remove_cvr.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/tcpsession.hpp
+++ b/src/alps/ngs/detail/tcpsession.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/detail/type_wrapper.hpp
+++ b/src/alps/ngs/detail/type_wrapper.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/hash.hpp
+++ b/src/alps/ngs/hash.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/api.cpp
+++ b/src/alps/ngs/lib/api.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/clone.cpp
+++ b/src/alps/ngs/lib/clone.cpp
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/lib/clone_info.cpp
+++ b/src/alps/ngs/lib/clone_info.cpp
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/lib/get_numpy_type.cpp
+++ b/src/alps/ngs/lib/get_numpy_type.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/job.cpp
+++ b/src/alps/ngs/lib/job.cpp
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/lib/make_deprecated_parameters.cpp
+++ b/src/alps/ngs/lib/make_deprecated_parameters.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/make_parameters_from_xml.cpp
+++ b/src/alps/ngs/lib/make_parameters_from_xml.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/mcobservable.cpp
+++ b/src/alps/ngs/lib/mcobservable.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/mcobservables.cpp
+++ b/src/alps/ngs/lib/mcobservables.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/mcoptions.cpp
+++ b/src/alps/ngs/lib/mcoptions.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/mcresult.cpp
+++ b/src/alps/ngs/lib/mcresult.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/mcresult_impl_base.ipp
+++ b/src/alps/ngs/lib/mcresult_impl_base.ipp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/mcresult_impl_derived.ipp
+++ b/src/alps/ngs/lib/mcresult_impl_derived.ipp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/mcresults.cpp
+++ b/src/alps/ngs/lib/mcresults.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/observablewrappers.cpp
+++ b/src/alps/ngs/lib/observablewrappers.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/paramproxy.cpp
+++ b/src/alps/ngs/lib/paramproxy.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/params.cpp
+++ b/src/alps/ngs/lib/params.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/paramvalue.cpp
+++ b/src/alps/ngs/lib/paramvalue.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/parapack.cpp
+++ b/src/alps/ngs/lib/parapack.cpp
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/lib/short_print.cpp
+++ b/src/alps/ngs/lib/short_print.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/signal.cpp
+++ b/src/alps/ngs/lib/signal.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/sleep.cpp
+++ b/src/alps/ngs/lib/sleep.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/stacktrace.cpp
+++ b/src/alps/ngs/lib/stacktrace.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/ulfm.cpp
+++ b/src/alps/ngs/lib/ulfm.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2012-2013 Donjan Rodic <drodic@phys.ethz.ch>                      *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/lib/worker_factory.cpp
+++ b/src/alps/ngs/lib/worker_factory.cpp
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/make_deprecated_parameters.hpp
+++ b/src/alps/ngs/make_deprecated_parameters.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/make_parameters_from_xml.hpp
+++ b/src/alps/ngs/make_parameters_from_xml.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/mcobservable.hpp
+++ b/src/alps/ngs/mcobservable.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/mcobservables.hpp
+++ b/src/alps/ngs/mcobservables.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/mcoptions.hpp
+++ b/src/alps/ngs/mcoptions.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/mcresult.hpp
+++ b/src/alps/ngs/mcresult.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/mcresults.hpp
+++ b/src/alps/ngs/mcresults.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/mpi.hpp
+++ b/src/alps/ngs/mpi.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/mutex.hpp
+++ b/src/alps/ngs/mutex.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/numeric.hpp
+++ b/src/alps/ngs/numeric.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/numeric/array.hpp
+++ b/src/alps/ngs/numeric/array.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  * Copyright (C) 2012 - 2014 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/numeric/detail.hpp
+++ b/src/alps/ngs/numeric/detail.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  * Copyright (C) 2012 - 2014 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/numeric/inf.hpp
+++ b/src/alps/ngs/numeric/inf.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  * Copyright (C) 2012 - 2014 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/numeric/multi_array.hpp
+++ b/src/alps/ngs/numeric/multi_array.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2014 by Jan Gukelberger <gukelberger@phys.ethz.ch>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/numeric/vector.hpp
+++ b/src/alps/ngs/numeric/vector.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  * Copyright (C) 2012 - 2014 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/observablewrappers.hpp
+++ b/src/alps/ngs/observablewrappers.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/params.hpp
+++ b/src/alps/ngs/params.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/parapack/clone.h
+++ b/src/alps/ngs/parapack/clone.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/parapack/clone_info.h
+++ b/src/alps/ngs/parapack/clone_info.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/parapack/clone_info_p.h
+++ b/src/alps/ngs/parapack/clone_info_p.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/parapack/clone_proxy.h
+++ b/src/alps/ngs/parapack/clone_proxy.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/parapack/job.h
+++ b/src/alps/ngs/parapack/job.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/parapack/job_p.h
+++ b/src/alps/ngs/parapack/job_p.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/parapack/params_p.h
+++ b/src/alps/ngs/parapack/params_p.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/parapack/parapack.h
+++ b/src/alps/ngs/parapack/parapack.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/parapack/simulation_p.h
+++ b/src/alps/ngs/parapack/simulation_p.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/parapack/worker_factory.h
+++ b/src/alps/ngs/parapack/worker_factory.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/ngs/python/accumulator.cpp
+++ b/src/alps/ngs/python/accumulator.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/python/api.cpp
+++ b/src/alps/ngs/python/api.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/python/hdf5.cpp
+++ b/src/alps/ngs/python/hdf5.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/python/mcbase.cpp
+++ b/src/alps/ngs/python/mcbase.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/python/observable.cpp
+++ b/src/alps/ngs/python/observable.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/python/observables.cpp
+++ b/src/alps/ngs/python/observables.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/python/params.cpp
+++ b/src/alps/ngs/python/params.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/python/random01.cpp
+++ b/src/alps/ngs/python/random01.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/python/result.cpp
+++ b/src/alps/ngs/python/result.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/python/results.cpp
+++ b/src/alps/ngs/python/results.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/random01.hpp
+++ b/src/alps/ngs/random01.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/result.hpp
+++ b/src/alps/ngs/result.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/scheduler/proto/controlthreadsim.hpp
+++ b/src/alps/ngs/scheduler/proto/controlthreadsim.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/scheduler/proto/mcbase.hpp
+++ b/src/alps/ngs/scheduler/proto/mcbase.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/scheduler/proto/mpisim.hpp
+++ b/src/alps/ngs/scheduler/proto/mpisim.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/scheduler/proto/mpisim_ulfm.hpp
+++ b/src/alps/ngs/scheduler/proto/mpisim_ulfm.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Donjan Rdoic <drodic@phys.ethz.ch>                 *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/scheduler/proto/tcpserver.hpp
+++ b/src/alps/ngs/scheduler/proto/tcpserver.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/scheduler/tcpserver.hpp
+++ b/src/alps/ngs/scheduler/tcpserver.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/short_print.hpp
+++ b/src/alps/ngs/short_print.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/signal.hpp
+++ b/src/alps/ngs/signal.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/sleep.hpp
+++ b/src/alps/ngs/sleep.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/stacktrace.hpp
+++ b/src/alps/ngs/stacktrace.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/stringify.hpp
+++ b/src/alps/ngs/stringify.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/thread_exceptions.hpp
+++ b/src/alps/ngs/thread_exceptions.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/ngs/ulfm.hpp
+++ b/src/alps/ngs/ulfm.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2012-2013 Donjan Rodic <drodic@phys.ethz.ch>                      *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
  

--- a/src/alps/numeric/abs2.hpp
+++ b/src/alps/numeric/abs2.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/accumulate_if.hpp
+++ b/src/alps/numeric/accumulate_if.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                       Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/binomial.hpp
+++ b/src/alps/numeric/binomial.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/checked_divide.hpp
+++ b/src/alps/numeric/checked_divide.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/conj.hpp
+++ b/src/alps/numeric/conj.hpp
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Andreas Hehn <hehn@phys.ethz.ch>                   
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/deprecated/vector.hpp
+++ b/src/alps/numeric/deprecated/vector.hpp
@@ -8,23 +8,8 @@
  *                              Brigitte Surer <surerb@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
  

--- a/src/alps/numeric/detail/deprecated/blasheader.hpp
+++ b/src/alps/numeric/detail/deprecated/blasheader.hpp
@@ -7,23 +7,8 @@
  *                              Emanuel Gull <gull@phys.columbia.edu>,
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/detail/deprecated/blasmacros.h
+++ b/src/alps/numeric/detail/deprecated/blasmacros.h
@@ -6,23 +6,8 @@
  * Copyright (C) 2010 Matthias Troyer <gtroyer@ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/detail/deprecated/general_matrix.hpp
+++ b/src/alps/numeric/detail/deprecated/general_matrix.hpp
@@ -8,23 +8,8 @@
  *                              Brigitte Surer <surerb@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/detail/deprecated/matrix.hpp
+++ b/src/alps/numeric/detail/deprecated/matrix.hpp
@@ -8,23 +8,8 @@
  *                              Brigitte Surer <surerb@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/detail/deprecated/vector.hpp
+++ b/src/alps/numeric/detail/deprecated/vector.hpp
@@ -8,23 +8,8 @@
  *                              Brigitte Surer <surerb@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
  

--- a/src/alps/numeric/diagonal_matrix.hpp
+++ b/src/alps/numeric/diagonal_matrix.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/double2int.hpp
+++ b/src/alps/numeric/double2int.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/fourier.hpp
+++ b/src/alps/numeric/fourier.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                       Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/functional.hpp
+++ b/src/alps/numeric/functional.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Lukas Gamper <gamperl@gmail.com>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/imag.hpp
+++ b/src/alps/numeric/imag.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1999-2010 by Bela Bauer <bauerb@cnsi.ucsb.edu>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/is_equal.hpp
+++ b/src/alps/numeric/is_equal.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/is_negative.hpp
+++ b/src/alps/numeric/is_negative.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/is_nonzero.hpp
+++ b/src/alps/numeric/is_nonzero.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/is_positive.hpp
+++ b/src/alps/numeric/is_positive.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/is_zero.hpp
+++ b/src/alps/numeric/is_zero.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/isinf.hpp
+++ b/src/alps/numeric/isinf.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2011 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/isnan.hpp
+++ b/src/alps/numeric/isnan.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2011 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/matrix.hpp
+++ b/src/alps/numeric/matrix.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/algorithms.hpp
+++ b/src/alps/numeric/matrix/algorithms.hpp
@@ -9,23 +9,8 @@
  *                              Michele Dolfi <dolfim@phys.ethz.ch>                *
  *                              Tim Ewart <timothee.ewart@unige.ch>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/column_view.hpp
+++ b/src/alps/numeric/matrix/column_view.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_COLUMN_VIEW_HPP

--- a/src/alps/numeric/matrix/conj.hpp
+++ b/src/alps/numeric/matrix/conj.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/detail/auto_deduce_multiply_return_type.hpp
+++ b/src/alps/numeric/matrix/detail/auto_deduce_multiply_return_type.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/detail/auto_deduce_plus_return_type.hpp
+++ b/src/alps/numeric/matrix/detail/auto_deduce_plus_return_type.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/detail/blasmacros.hpp
+++ b/src/alps/numeric/matrix/detail/blasmacros.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/detail/column_view_adaptor.hpp
+++ b/src/alps/numeric/matrix/detail/column_view_adaptor.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_COLUMN_VIEW_ADAPTOR_HPP

--- a/src/alps/numeric/matrix/detail/debug_output.hpp
+++ b/src/alps/numeric/matrix/detail/debug_output.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_DETAIL_DEBUG_OUTPUT_HPP

--- a/src/alps/numeric/matrix/detail/matrix_adaptor.hpp
+++ b/src/alps/numeric/matrix/detail/matrix_adaptor.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/detail/print_matrix.hpp
+++ b/src/alps/numeric/matrix/detail/print_matrix.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_DETAIL_PRINT_MATRIX_HPP

--- a/src/alps/numeric/matrix/detail/print_vector.hpp
+++ b/src/alps/numeric/matrix/detail/print_vector.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_DETAIL_PRINT_VECTOR_HPP

--- a/src/alps/numeric/matrix/detail/transpose_view_adaptor.hpp
+++ b/src/alps/numeric/matrix/detail/transpose_view_adaptor.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/detail/vector_adaptor.hpp
+++ b/src/alps/numeric/matrix/detail/vector_adaptor.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/entity.hpp
+++ b/src/alps/numeric/matrix/entity.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_ENTITY_HPP

--- a/src/alps/numeric/matrix/exchange_value_type.hpp
+++ b/src/alps/numeric/matrix/exchange_value_type.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_EXCHANGE_VALUE_TYPE_HPP

--- a/src/alps/numeric/matrix/gemm.hpp
+++ b/src/alps/numeric/matrix/gemm.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_GEMM_HPP

--- a/src/alps/numeric/matrix/gemv.hpp
+++ b/src/alps/numeric/matrix/gemv.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_GEMV_HPP

--- a/src/alps/numeric/matrix/is_blas_dispatchable.hpp
+++ b/src/alps/numeric/matrix/is_blas_dispatchable.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_IS_BLAS_DISPATCHABLE_HPP

--- a/src/alps/numeric/matrix/matrix.hpp
+++ b/src/alps/numeric/matrix/matrix.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/matrix.ipp
+++ b/src/alps/numeric/matrix/matrix.ipp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/matrix_concept_archetype.hpp
+++ b/src/alps/numeric/matrix/matrix_concept_archetype.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_MATRIX_CONCEPT_ARCHETYPE_HPP

--- a/src/alps/numeric/matrix/matrix_concept_check.hpp
+++ b/src/alps/numeric/matrix/matrix_concept_check.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/matrix_element_iterator.hpp
+++ b/src/alps/numeric/matrix/matrix_element_iterator.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/matrix_interface.hpp
+++ b/src/alps/numeric/matrix/matrix_interface.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/matrix_traits.hpp
+++ b/src/alps/numeric/matrix/matrix_traits.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/operators/multiply.hpp
+++ b/src/alps/numeric/matrix/operators/multiply.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_OPERATORS_MULTIPLY_HPP

--- a/src/alps/numeric/matrix/operators/multiply_matrix.hpp
+++ b/src/alps/numeric/matrix/operators/multiply_matrix.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_OPERATORS_MULTIPLY_MATRIX_HPP

--- a/src/alps/numeric/matrix/operators/multiply_scalar.hpp
+++ b/src/alps/numeric/matrix/operators/multiply_scalar.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/operators/op_assign.hpp
+++ b/src/alps/numeric/matrix/operators/op_assign.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_OPERATORS_OP_ASSIGN_HPP

--- a/src/alps/numeric/matrix/operators/op_assign_matrix.hpp
+++ b/src/alps/numeric/matrix/operators/op_assign_matrix.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_OPERATORS_OP_ASSIGN_MATRIX_HPP

--- a/src/alps/numeric/matrix/operators/op_assign_vector.hpp
+++ b/src/alps/numeric/matrix/operators/op_assign_vector.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_OPERATORS_OP_ASSIGN_VECTOR_HPP

--- a/src/alps/numeric/matrix/operators/plus_minus.hpp
+++ b/src/alps/numeric/matrix/operators/plus_minus.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_OPERATORS_PLUS_MINUS_HPP

--- a/src/alps/numeric/matrix/resizable_matrix_concept_check.hpp
+++ b/src/alps/numeric/matrix/resizable_matrix_concept_check.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/resizable_matrix_interface.hpp
+++ b/src/alps/numeric/matrix/resizable_matrix_interface.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/scalar_product.hpp
+++ b/src/alps/numeric/matrix/scalar_product.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_SCALAR_PRODUCT_HPP

--- a/src/alps/numeric/matrix/strided_iterator.hpp
+++ b/src/alps/numeric/matrix/strided_iterator.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/transpose.hpp
+++ b/src/alps/numeric/matrix/transpose.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2012 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/transpose_view.hpp
+++ b/src/alps/numeric/matrix/transpose_view.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2012 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix/ublas_sparse_functions.hpp
+++ b/src/alps/numeric/matrix/ublas_sparse_functions.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_NUMERIC_MATRIX_UBLAS_SPARSE_FUNCTIONS_HPP

--- a/src/alps/numeric/matrix/vector.hpp
+++ b/src/alps/numeric/matrix/vector.hpp
@@ -9,23 +9,8 @@
  *                              Andreas Hehn <hehn@phys.ethz.ch>
  *
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/src/alps/numeric/matrix/vector_interface.hpp
+++ b/src/alps/numeric/matrix/vector_interface.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/numeric/matrix_as_vector.hpp
+++ b/src/alps/numeric/matrix_as_vector.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/outer_product.hpp
+++ b/src/alps/numeric/outer_product.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/polynomial.hpp
+++ b/src/alps/numeric/polynomial.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                       Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/real.hpp
+++ b/src/alps/numeric/real.hpp
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Andreas Hehn <hehn@phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/regression.hpp
+++ b/src/alps/numeric/regression.hpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/round.hpp
+++ b/src/alps/numeric/round.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/scalar_product.hpp
+++ b/src/alps/numeric/scalar_product.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/sequence_comparisons.hpp
+++ b/src/alps/numeric/sequence_comparisons.hpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/set_negative_0.hpp
+++ b/src/alps/numeric/set_negative_0.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/special_functions.hpp
+++ b/src/alps/numeric/special_functions.hpp
@@ -8,23 +8,8 @@
 *                            Lukas Gamper <gamperl@gmail.com>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/update_minmax.hpp
+++ b/src/alps/numeric/update_minmax.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/valarray_functions.hpp
+++ b/src/alps/numeric/valarray_functions.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/vector_functions.hpp
+++ b/src/alps/numeric/vector_functions.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/numeric/vector_valarray_conversion.hpp
+++ b/src/alps/numeric/vector_valarray_conversion.hpp
@@ -8,23 +8,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris.h
+++ b/src/alps/osiris.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2005 by Synge Todo <wistaria@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/archivedump.h
+++ b/src/alps/osiris/archivedump.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/boost/array.h
+++ b/src/alps/osiris/boost/array.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/boost/ublas.h
+++ b/src/alps/osiris/boost/ublas.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2011 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/buffer.C
+++ b/src/alps/osiris/buffer.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/buffer.h
+++ b/src/alps/osiris/buffer.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/comm.C
+++ b/src/alps/osiris/comm.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/comm.h
+++ b/src/alps/osiris/comm.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/dump.C
+++ b/src/alps/osiris/dump.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/dump.h
+++ b/src/alps/osiris/dump.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/dumparchive.C
+++ b/src/alps/osiris/dumparchive.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                       Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/dumparchive.h
+++ b/src/alps/osiris/dumparchive.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2008 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/mpdump.C
+++ b/src/alps/osiris/mpdump.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/mpdump.h
+++ b/src/alps/osiris/mpdump.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/process.C
+++ b/src/alps/osiris/process.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/process.h
+++ b/src/alps/osiris/process.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/deque.h
+++ b/src/alps/osiris/std/deque.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/impl.h
+++ b/src/alps/osiris/std/impl.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/list.h
+++ b/src/alps/osiris/std/list.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/map.h
+++ b/src/alps/osiris/std/map.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/pair.h
+++ b/src/alps/osiris/std/pair.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/set.h
+++ b/src/alps/osiris/std/set.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/stack.h
+++ b/src/alps/osiris/std/stack.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2007 - 2010 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/string.h
+++ b/src/alps/osiris/std/string.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2002 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/valarray.h
+++ b/src/alps/osiris/std/valarray.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/std/vector.h
+++ b/src/alps/osiris/std/vector.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/xdrcore.C
+++ b/src/alps/osiris/xdrcore.C
@@ -7,23 +7,8 @@
 * This File:
 * Copyright (C) 2006 by Andreas Laeuchli <laeuchli@comp-phys.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/xdrdump.C
+++ b/src/alps/osiris/xdrdump.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/osiris/xdrdump.h
+++ b/src/alps/osiris/xdrdump.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter.h
+++ b/src/alps/parameter.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter/parameter.C
+++ b/src/alps/parameter/parameter.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter/parameter.h
+++ b/src/alps/parameter/parameter.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter/parameter_p.h
+++ b/src/alps/parameter/parameter_p.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter/parameterlist.C
+++ b/src/alps/parameter/parameterlist.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2008 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter/parameterlist.h
+++ b/src/alps/parameter/parameterlist.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter/parameterlist_p.h
+++ b/src/alps/parameter/parameterlist_p.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter/parameters.C
+++ b/src/alps/parameter/parameters.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2008 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter/parameters.h
+++ b/src/alps/parameter/parameters.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parameter/parameters_p.h
+++ b/src/alps/parameter/parameters_p.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/clone.C
+++ b/src/alps/parapack/clone.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2014 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/clone.h
+++ b/src/alps/parapack/clone.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/clone_info.C
+++ b/src/alps/parapack/clone_info.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2012 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/clone_info.h
+++ b/src/alps/parapack/clone_info.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/clone_info_p.h
+++ b/src/alps/parapack/clone_info_p.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/clone_proxy.h
+++ b/src/alps/parapack/clone_proxy.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/clone_timer.h
+++ b/src/alps/parapack/clone_timer.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/exchange.h
+++ b/src/alps/parapack/exchange.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/exchange_multi.h
+++ b/src/alps/parapack/exchange_multi.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/exp_number.h
+++ b/src/alps/parapack/exp_number.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/filelock.C
+++ b/src/alps/parapack/filelock.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/filelock.h
+++ b/src/alps/parapack/filelock.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/footprint.h
+++ b/src/alps/parapack/footprint.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/integer_range.h
+++ b/src/alps/parapack/integer_range.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/job.C
+++ b/src/alps/parapack/job.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/job.h
+++ b/src/alps/parapack/job.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/job_p.h
+++ b/src/alps/parapack/job_p.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/logger.C
+++ b/src/alps/parapack/logger.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/logger.h
+++ b/src/alps/parapack/logger.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2012 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/mc_worker.C
+++ b/src/alps/parapack/mc_worker.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/mc_worker.h
+++ b/src/alps/parapack/mc_worker.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/measurement.C
+++ b/src/alps/parapack/measurement.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/measurement.h
+++ b/src/alps/parapack/measurement.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/montecarlo.h
+++ b/src/alps/parapack/montecarlo.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/option.C
+++ b/src/alps/parapack/option.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/option.h
+++ b/src/alps/parapack/option.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/parapack.C
+++ b/src/alps/parapack/parapack.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/parapack.h
+++ b/src/alps/parapack/parapack.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/permutation.h
+++ b/src/alps/parapack/permutation.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/process.h
+++ b/src/alps/parapack/process.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/process_impl.C
+++ b/src/alps/parapack/process_impl.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/queue.C
+++ b/src/alps/parapack/queue.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/queue.h
+++ b/src/alps/parapack/queue.h
@@ -10,23 +10,8 @@
 *                            Tatsuya Sakashita <t-sakashita@issp.u-tokyo.ac.jp>,
 *                            Yuichi Motoyama <yomichi@looper.t.u-tokyo.ac.jp>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/rng_helper.C
+++ b/src/alps/parapack/rng_helper.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/rng_helper.h
+++ b/src/alps/parapack/rng_helper.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/simulation_p.h
+++ b/src/alps/parapack/simulation_p.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2012 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/temperature_scan.h
+++ b/src/alps/parapack/temperature_scan.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/types.C
+++ b/src/alps/parapack/types.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/types.h
+++ b/src/alps/parapack/types.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/util.C
+++ b/src/alps/parapack/util.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/util.h
+++ b/src/alps/parapack/util.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/version.C
+++ b/src/alps/parapack/version.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/version.h
+++ b/src/alps/parapack/version.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/wanglandau.h
+++ b/src/alps/parapack/wanglandau.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/worker.h
+++ b/src/alps/parapack/worker.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/worker_factory.C
+++ b/src/alps/parapack/worker_factory.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parapack/worker_factory.h
+++ b/src/alps/parapack/worker_factory.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parseargs.cpp
+++ b/src/alps/parseargs.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/parseargs.hpp
+++ b/src/alps/parseargs.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/parser/parser.C
+++ b/src/alps/parser/parser.C
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Prakash Dayal <prakash@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/parser.h
+++ b/src/alps/parser/parser.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xmlattributes.C
+++ b/src/alps/parser/xmlattributes.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xmlattributes.h
+++ b/src/alps/parser/xmlattributes.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xmlhandler.C
+++ b/src/alps/parser/xmlhandler.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xmlhandler.h
+++ b/src/alps/parser/xmlhandler.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xmlparser.C
+++ b/src/alps/parser/xmlparser.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2004 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xmlparser.h
+++ b/src/alps/parser/xmlparser.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xmlstream.C
+++ b/src/alps/parser/xmlstream.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2001-2005 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xmlstream.h
+++ b/src/alps/parser/xmlstream.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2001-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xslt_path.C
+++ b/src/alps/parser/xslt_path.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/parser/xslt_path.h
+++ b/src/alps/parser/xslt_path.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/plot.h
+++ b/src/alps/plot.h
@@ -8,23 +8,8 @@
 *                            Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/progress_callback.hpp
+++ b/src/alps/progress_callback.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2012 by Jan Gukelberger <gukel@comp-phys.org>                     *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/python/make_copy.hpp
+++ b/src/alps/python/make_copy.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/python/numpy_array.cpp
+++ b/src/alps/python/numpy_array.cpp
@@ -8,23 +8,8 @@
 *                            Lukas Gamper <gamperl@gmail.com>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/python/numpy_array.hpp
+++ b/src/alps/python/numpy_array.hpp
@@ -9,23 +9,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>
 *                            Michele Dolfi <dolfim@phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/python/numpy_import.hpp
+++ b/src/alps/python/numpy_import.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2016 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Jan Gukelberger <j.gukelberger@usherbrooke.ca>     *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/python/pyalea.cpp
+++ b/src/alps/python/pyalea.cpp
@@ -9,23 +9,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/python/pymcdata.cpp
+++ b/src/alps/python/pymcdata.cpp
@@ -8,23 +8,8 @@
 *                            Lukas Gamper <gamperl@gmail.com>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/python/pytools.cpp
+++ b/src/alps/python/pytools.cpp
@@ -8,23 +8,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Bela Bauer <bauerb@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/python/save_observable_to_hdf5.hpp
+++ b/src/alps/python/save_observable_to_hdf5.hpp
@@ -6,23 +6,8 @@
  *
  * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/src/alps/random.h
+++ b/src/alps/random.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/random/buffered_rng.h
+++ b/src/alps/random/buffered_rng.h
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Mario Ruetti <mruetti@gmx.net>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/random/pseudo_des.h
+++ b/src/alps/random/pseudo_des.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/random/random_choice.hpp
+++ b/src/alps/random/random_choice.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2014 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/random/rngfactory.C
+++ b/src/alps/random/rngfactory.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/random/rngfactory.h
+++ b/src/alps/random/rngfactory.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/random/seed.h
+++ b/src/alps/random/seed.h
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Mario Ruetti <mruetti@gmx.net>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/random/uniform_on_sphere_n.h
+++ b/src/alps/random/uniform_on_sphere_n.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2005 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler.h
+++ b/src/alps/scheduler.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2003 by Synge Todo <wistaria@comp-phys.org>,
 *                       and Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/abstract_task.C
+++ b/src/alps/scheduler/abstract_task.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/convert.h
+++ b/src/alps/scheduler/convert.h
@@ -8,23 +8,8 @@
 *                            Simon Trebst <trebst@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/convertxdr.C
+++ b/src/alps/scheduler/convertxdr.C
@@ -8,23 +8,8 @@
 *                            Simon Trebst <trebst@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/diag.hpp
+++ b/src/alps/scheduler/diag.hpp
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/factory.C
+++ b/src/alps/scheduler/factory.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/factory.h
+++ b/src/alps/scheduler/factory.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/info.C
+++ b/src/alps/scheduler/info.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/info.h
+++ b/src/alps/scheduler/info.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/master_scheduler.C
+++ b/src/alps/scheduler/master_scheduler.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/measurement_operators.C
+++ b/src/alps/scheduler/measurement_operators.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/measurement_operators.h
+++ b/src/alps/scheduler/measurement_operators.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/montecarlo.C
+++ b/src/alps/scheduler/montecarlo.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2002-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/montecarlo.h
+++ b/src/alps/scheduler/montecarlo.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/mpp_scheduler.C
+++ b/src/alps/scheduler/mpp_scheduler.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/options.C
+++ b/src/alps/scheduler/options.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/options.h
+++ b/src/alps/scheduler/options.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/remote_task.C
+++ b/src/alps/scheduler/remote_task.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/remote_worker.C
+++ b/src/alps/scheduler/remote_worker.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/scheduler.C
+++ b/src/alps/scheduler/scheduler.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/scheduler.h
+++ b/src/alps/scheduler/scheduler.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/serial_scheduler.C
+++ b/src/alps/scheduler/serial_scheduler.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/signal.C
+++ b/src/alps/scheduler/signal.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/signal.hpp
+++ b/src/alps/scheduler/signal.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/single_scheduler.C
+++ b/src/alps/scheduler/single_scheduler.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/slave_task.C
+++ b/src/alps/scheduler/slave_task.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *                            Synge Todo <wistaria@comph-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/task.C
+++ b/src/alps/scheduler/task.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/task.h
+++ b/src/alps/scheduler/task.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2002-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/types.h
+++ b/src/alps/scheduler/types.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/worker.C
+++ b/src/alps/scheduler/worker.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2005 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/worker.h
+++ b/src/alps/scheduler/worker.h
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/scheduler/workertask.C
+++ b/src/alps/scheduler/workertask.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/stop_callback.cpp
+++ b/src/alps/stop_callback.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>,                  *
  *                              Synge Todo <wistaria@comp-phys.org>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/stop_callback.hpp
+++ b/src/alps/stop_callback.hpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>,                  *
  *                              Synge Todo <wistaria@comp-phys.org>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/src/alps/stringvalue.h
+++ b/src/alps/stringvalue.h
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Mathias Koerner <mkoerner@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/average_type.hpp
+++ b/src/alps/type_traits/average_type.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/change_value_type.hpp
+++ b/src/alps/type_traits/change_value_type.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/covariance_type.hpp
+++ b/src/alps/type_traits/covariance_type.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/element_type.hpp
+++ b/src/alps/type_traits/element_type.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/has_value_type.hpp
+++ b/src/alps/type_traits/has_value_type.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/is_complex.hpp
+++ b/src/alps/type_traits/is_complex.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/is_scalar.hpp
+++ b/src/alps/type_traits/is_scalar.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/is_sequence.hpp
+++ b/src/alps/type_traits/is_sequence.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/is_symbolic.hpp
+++ b/src/alps/type_traits/is_symbolic.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/iterator_type.hpp
+++ b/src/alps/type_traits/iterator_type.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/norm_type.hpp
+++ b/src/alps/type_traits/norm_type.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/param_type.hpp
+++ b/src/alps/type_traits/param_type.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/real_type.hpp
+++ b/src/alps/type_traits/real_type.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/slice.hpp
+++ b/src/alps/type_traits/slice.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/type_traits/type_tag.hpp
+++ b/src/alps/type_traits/type_tag.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/assign.hpp
+++ b/src/alps/utility/assign.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/bitops.hpp
+++ b/src/alps/utility/bitops.hpp
@@ -8,23 +8,8 @@
 *                            Andreas Laeuchli <laeuchli@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/copyright.cpp
+++ b/src/alps/utility/copyright.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2011 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/copyright.hpp
+++ b/src/alps/utility/copyright.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2010 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/data.hpp
+++ b/src/alps/utility/data.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1999-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/factory.hpp
+++ b/src/alps/utility/factory.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/make_copy.hpp
+++ b/src/alps/utility/make_copy.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Matthias Troyer <troyer@comp-phys.org>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/numeric_cast.hpp
+++ b/src/alps/utility/numeric_cast.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/os.cpp
+++ b/src/alps/utility/os.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2008 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/os.hpp
+++ b/src/alps/utility/os.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/resize.hpp
+++ b/src/alps/utility/resize.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/set_zero.hpp
+++ b/src/alps/utility/set_zero.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/size.hpp
+++ b/src/alps/utility/size.hpp
@@ -9,23 +9,8 @@
 *                            Andreas Laeuchli <laeuchli@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/vectorio.hpp
+++ b/src/alps/utility/vectorio.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2008 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/vmusage.cpp
+++ b/src/alps/utility/vmusage.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2010-2012 by Haruhiko Matsuo <halm@looper.t.u-tokyo.ac.jp>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/utility/vmusage.hpp
+++ b/src/alps/utility/vmusage.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2010-2012 by Haruhiko Matsuo <halm@looper.t.u-tokyo.ac.jp>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/version.h.in
+++ b/src/alps/version.h.in
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/alps/xml.h
+++ b/src/alps/xml.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/boost/classic_spirit.hpp
+++ b/src/boost/classic_spirit.hpp
@@ -6,22 +6,8 @@
 *
 * Copyright (C) 2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* This software is part of the ALPS libraries, published under the ALPS
-* Library License; you can use, redistribute it and/or modify it under
-* the terms of the license, either version 1 or (at your option) any later
-* version.
-* 
-* You should have received a copy of the ALPS Library License along with
-* the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-* available from http://alps.comp-phys.org/.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/boost/function_objects.hpp
+++ b/src/boost/function_objects.hpp
@@ -6,22 +6,8 @@
 *
 * Copyright (C) 2003 by Matthias Troyer <troyer@comp-phys.org>
 *
-* This software is part of the ALPS libraries, published under the ALPS
-* Library License; you can use, redistribute it and/or modify it under
-* the terms of the license, either version 1 or (at your option) any later
-* version.
-* 
-* You should have received a copy of the ALPS Library License along with
-* the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-* available from http://alps.comp-phys.org/.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/boost/throw_exception.C
+++ b/src/boost/throw_exception.C
@@ -7,22 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* This software is part of the ALPS libraries, published under the ALPS
-* Library License; you can use, redistribute it and/or modify it under
-* the terms of the license, either version 1 or (at your option) any later
-* version.
-* 
-* You should have received a copy of the ALPS Library License along with
-* the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-* available from http://alps.comp-phys.org/.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/bandlanczos.h
+++ b/src/ietl/bandlanczos.h
@@ -8,23 +8,8 @@
 *                            Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/bicgstabl.h
+++ b/src/ietl/bicgstabl.h
@@ -6,23 +6,8 @@
  *
  * Copyright (C) 20XX ??
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/src/ietl/cg.h
+++ b/src/ietl/cg.h
@@ -6,23 +6,8 @@
  *
  * Copyright (C) 2001-2011 by Bela Bauer <bauerb@phys.ethz.ch>
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
  

--- a/src/ietl/complex.h
+++ b/src/ietl/complex.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2002 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/config.h.in
+++ b/src/ietl/config.h.in
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/fmatrix.h
+++ b/src/ietl/fmatrix.h
@@ -8,23 +8,8 @@
 *                            Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/gmres.h
+++ b/src/ietl/gmres.h
@@ -6,23 +6,8 @@
  *
  * Copyright (C) 2011 by Bela Bauer <bauerb@phys.ethz.ch>
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
  

--- a/src/ietl/ietl2lapack.h
+++ b/src/ietl/ietl2lapack.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2010 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/interface/blas.h
+++ b/src/ietl/interface/blas.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2004 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/interface/blitz.h
+++ b/src/ietl/interface/blitz.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/interface/mtl.h
+++ b/src/ietl/interface/mtl.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2004 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/interface/ublas.h
+++ b/src/ietl/interface/ublas.h
@@ -8,23 +8,8 @@
  *                            Matthias Troyer <troyer@comp-phys.org>
  *                            Bela Bauer <bauerb@phys.ethz.ch>
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/src/ietl/interface/valarray.h
+++ b/src/ietl/interface/valarray.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/inverse.h
+++ b/src/ietl/inverse.h
@@ -8,23 +8,8 @@
 *                            Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/iteration.h
+++ b/src/ietl/iteration.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/jacobi.h
+++ b/src/ietl/jacobi.h
@@ -9,23 +9,8 @@
  *                            Matthias Troyer <troyer@comp-phys.org>
  *                            Bela Bauer <bauerb@phys.ethz.ch>
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/src/ietl/jd.h
+++ b/src/ietl/jd.h
@@ -7,23 +7,8 @@
  *
  * Copyright (C) 2011 by Robin Jaeger <jaegerr@phys.ethz.ch>
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef JACOBI_DAVIDSON_H

--- a/src/ietl/krylov_wrapper.h
+++ b/src/ietl/krylov_wrapper.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002 by Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/lanczos.h
+++ b/src/ietl/lanczos.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2011 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/matrix.h
+++ b/src/ietl/matrix.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2002 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/power.h
+++ b/src/ietl/power.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/rayleigh.h
+++ b/src/ietl/rayleigh.h
@@ -8,23 +8,8 @@
 *                            Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/tmatrix.h
+++ b/src/ietl/tmatrix.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2011 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/traits.h
+++ b/src/ietl/traits.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2002 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/src/ietl/vectorspace.h
+++ b/src/ietl/vectorspace.h
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2002 by Prakash Dayal <prakash@comp-phys.org>,
 *                            Matthias Troyer <troyer@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/accumulator/count.cpp
+++ b/test/accumulator/count.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/accumulator/mean.cpp
+++ b/test/accumulator/mean.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/alea/binned_data.C
+++ b/test/alea/binned_data.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/complexobservable.C
+++ b/test/alea/complexobservable.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/detailedbinning.C
+++ b/test/alea/detailedbinning.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2007 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/dumpbench.C
+++ b/test/alea/dumpbench.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Lukas Gamper <gamperl -at- gmail.com>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/histogram.C
+++ b/test/alea/histogram.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/histogram2.C
+++ b/test/alea/histogram2.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/mcanalyze.C
+++ b/test/alea/mcanalyze.C
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/mcdata.C
+++ b/test/alea/mcdata.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2008 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/mcdata2.C
+++ b/test/alea/mcdata2.C
@@ -8,23 +8,8 @@
 *                            Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/mcdata_transform_variance.C
+++ b/test/alea/mcdata_transform_variance.C
@@ -4,23 +4,8 @@
 *
 * Copyright (C) 1994-2025 by the ALPS collaboration
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the "Software"),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/observableset_hdf5.C
+++ b/test/alea/observableset_hdf5.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2010-2012 by Lukas Gamper <gamperl -at- gmail.com>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/observableset_mpi.C
+++ b/test/alea/observableset_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/observableset_xml.C
+++ b/test/alea/observableset_xml.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/signed.C
+++ b/test/alea/signed.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/simpleobseval.C
+++ b/test/alea/simpleobseval.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2008 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/testobservableset.C
+++ b/test/alea/testobservableset.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2006 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/alea/vectorobseval.C
+++ b/test/alea/vectorobseval.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/fixed_capacity/fixed_capacity_deque.C
+++ b/test/fixed_capacity/fixed_capacity_deque.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/fixed_capacity/fixed_capacity_traits.C
+++ b/test/fixed_capacity/fixed_capacity_traits.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/fixed_capacity/fixed_capacity_vector.C
+++ b/test/fixed_capacity/fixed_capacity_vector.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/fixed_capacity/test_deque.C
+++ b/test/fixed_capacity/test_deque.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/fixed_capacity/test_main.h
+++ b/test/fixed_capacity/test_main.h
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2004 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/fixed_capacity/test_vector.C
+++ b/test/fixed_capacity/test_vector.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/fixed_capacity/timing_queue.C
+++ b/test/fixed_capacity/timing_queue.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/fixed_capacity/timing_stack.C
+++ b/test/fixed_capacity/timing_stack.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/fixed_capacity/timing_vector.C
+++ b/test/fixed_capacity/timing_vector.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/graph/canonical_label_random_graphs_test.cpp
+++ b/test/graph/canonical_label_random_graphs_test.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #include "generate_random_graph.hpp"

--- a/test/graph/canonical_label_test.cpp
+++ b/test/graph/canonical_label_test.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/canonical_label_with_color_symmetries_test.cpp
+++ b/test/graph/canonical_label_with_color_symmetries_test.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/colored_lattice_constant_test.cpp
+++ b/test/graph/colored_lattice_constant_test.cpp
@@ -8,23 +8,8 @@
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                              Robin Jaeger <jaegerr@phys.ethz.ch>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/colored_lattice_constant_test2.cpp
+++ b/test/graph/colored_lattice_constant_test2.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2012 - 2015 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/embedding_test.cpp
+++ b/test/graph/embedding_test.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/generate_random_graph.hpp
+++ b/test/graph/generate_random_graph.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2015 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef ALPS_TEST_GENERATE_RANDOM_GRAPH_HPP

--- a/test/graph/is_embeddable_with_color_symmetries_test.cpp
+++ b/test/graph/is_embeddable_with_color_symmetries_test.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/iso_simple.cpp
+++ b/test/graph/iso_simple.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/lattice_constant_matrix.cpp
+++ b/test/graph/lattice_constant_matrix.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2012 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                       Lukas Gamper <gamperl@gmail.com>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/lattice_constant_square_test.cpp
+++ b/test/graph/lattice_constant_square_test.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/lattice_constant_tri_test.cpp
+++ b/test/graph/lattice_constant_tri_test.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2016 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/orbit_test.cpp
+++ b/test/graph/orbit_test.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/subgraph_generator_test.cpp
+++ b/test/graph/subgraph_generator_test.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/subgraph_generator_test_colored_edges.cpp
+++ b/test/graph/subgraph_generator_test_colored_edges.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2012 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/subgraph_generator_test_colored_edges2.cpp
+++ b/test/graph/subgraph_generator_test_colored_edges2.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2011 - 2013 by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                              Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/subgraph_generator_test_colored_edges_with_sym.cpp
+++ b/test/graph/subgraph_generator_test_colored_edges_with_sym.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/subgraph_generator_test_colored_edges_with_sym2.cpp
+++ b/test/graph/subgraph_generator_test_colored_edges_with_sym2.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/graph/utils_test.cpp
+++ b/test/graph/utils_test.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2015 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #include <boost/graph/adjacency_list.hpp>

--- a/test/hdf5/creator.hpp
+++ b/test/hdf5/creator.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_bool.cpp
+++ b/test/hdf5/hdf5_bool.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_complex.cpp
+++ b/test/hdf5/hdf5_complex.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_copy.cpp
+++ b/test/hdf5/hdf5_copy.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_exceptions.cpp
+++ b/test/hdf5/hdf5_exceptions.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_family.cpp
+++ b/test/hdf5/hdf5_family.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_fortran_string.cpp
+++ b/test/hdf5/hdf5_fortran_string.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_ising.cpp
+++ b/test/hdf5/hdf5_ising.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2003 by Brigitte Surer and Jan Gukelberger                        *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_large.cpp
+++ b/test/hdf5/hdf5_large.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_memory.cpp
+++ b/test/hdf5/hdf5_memory.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_misc.cpp
+++ b/test/hdf5/hdf5_misc.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_multi_array.cpp
+++ b/test/hdf5/hdf5_multi_array.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_multiarchive.cpp
+++ b/test/hdf5/hdf5_multiarchive.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_observableset.cpp
+++ b/test/hdf5/hdf5_observableset.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_omp.cpp
+++ b/test/hdf5/hdf5_omp.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_pair.cpp
+++ b/test/hdf5/hdf5_pair.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_parms.cpp
+++ b/test/hdf5/hdf5_parms.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_real_complex.cpp
+++ b/test/hdf5/hdf5_real_complex.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Michele Dolfi <dolfim@phys.ethz.ch>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_real_complex_matrix.cpp
+++ b/test/hdf5/hdf5_real_complex_matrix.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Michele Dolfi <dolfim@phys.ethz.ch>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_real_complex_vec.cpp
+++ b/test/hdf5/hdf5_real_complex_vec.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Michele Dolfi <dolfim@phys.ethz.ch>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_replace.cpp
+++ b/test/hdf5/hdf5_replace.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_valgrind.cpp
+++ b/test/hdf5/hdf5_valgrind.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_vecveccplx.cpp
+++ b/test/hdf5/hdf5_vecveccplx.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/hdf5_vecvecdbl.cpp
+++ b/test/hdf5/hdf5_vecvecdbl.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/hdf5/type_check.cpp.in
+++ b/test/hdf5/type_check.cpp.in
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/lattice/coloring.C
+++ b/test/lattice/coloring.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example1.C
+++ b/test/lattice/example1.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example10.C
+++ b/test/lattice/example10.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example11.C
+++ b/test/lattice/example11.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2001-2007 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example2.C
+++ b/test/lattice/example2.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example3.C
+++ b/test/lattice/example3.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example4.C
+++ b/test/lattice/example4.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example5.C
+++ b/test/lattice/example5.C
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Ian McCulloch <ianmcc@physik.rwth-aachen.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example6.C
+++ b/test/lattice/example6.C
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Ian McCulloch <ianmcc@physik.rwth-aachen.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example7.C
+++ b/test/lattice/example7.C
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Ian McCulloch <ianmcc@physics.uq.edu.au>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example8.C
+++ b/test/lattice/example8.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/example9.C
+++ b/test/lattice/example9.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/label.C
+++ b/test/lattice/label.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/lattice/parity.C
+++ b/test/lattice/parity.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example1.C
+++ b/test/model/example1.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example10.C
+++ b/test/model/example10.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example11.C
+++ b/test/model/example11.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example12.C
+++ b/test/model/example12.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example13.C
+++ b/test/model/example13.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example14.C
+++ b/test/model/example14.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example15.C
+++ b/test/model/example15.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example16.C
+++ b/test/model/example16.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example17.C
+++ b/test/model/example17.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example18.C
+++ b/test/model/example18.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example2.C
+++ b/test/model/example2.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example3.C
+++ b/test/model/example3.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example4.C
+++ b/test/model/example4.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example5.C
+++ b/test/model/example5.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example6.C
+++ b/test/model/example6.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Axel Grzesik <axel@th.physik.uni-bonn.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example7.C
+++ b/test/model/example7.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Axel Grzesik <axel@th.physik.uni-bonn.de>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example8.C
+++ b/test/model/example8.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/model/example9.C
+++ b/test/model/example9.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003-2004 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/ngs/alea/error_archetype.hpp
+++ b/test/ngs/alea/error_archetype.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/hist_archetype.hpp
+++ b/test/ngs/alea/hist_archetype.hpp
@@ -6,23 +6,8 @@
  *
  * Copyright (C) 1997-2011 by Lukas Gamper
  *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 #ifndef HIST_ARCHETYPE_HEADER

--- a/test/ngs/alea/mean_archetype.hpp
+++ b/test/ngs/alea/mean_archetype.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_compare.cpp
+++ b/test/ngs/alea/ngs_alea_compare.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_count_test_compile.cpp
+++ b/test/ngs/alea/ngs_alea_count_test_compile.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_count_test_runtime.cpp
+++ b/test/ngs/alea/ngs_alea_count_test_runtime.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_ctor_test_compile.cpp
+++ b/test/ngs/alea/ngs_alea_ctor_test_compile.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_ctor_test_runtime.cpp
+++ b/test/ngs/alea/ngs_alea_ctor_test_runtime.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_error_test_compile.cpp
+++ b/test/ngs/alea/ngs_alea_error_test_compile.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_error_test_runtime.cpp
+++ b/test/ngs/alea/ngs_alea_error_test_runtime.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_fix_size_test_compile.cpp
+++ b/test/ngs/alea/ngs_alea_fix_size_test_compile.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_fix_size_test_runtime.cpp
+++ b/test/ngs/alea/ngs_alea_fix_size_test_runtime.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_log_test_compile.cpp
+++ b/test/ngs/alea/ngs_alea_log_test_compile.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_log_test_runtime.cpp
+++ b/test/ngs/alea/ngs_alea_log_test_runtime.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_max_num_test_compile.cpp
+++ b/test/ngs/alea/ngs_alea_max_num_test_compile.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_max_num_test_runtime.cpp
+++ b/test/ngs/alea/ngs_alea_max_num_test_runtime.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_mean_test_compile.cpp
+++ b/test/ngs/alea/ngs_alea_mean_test_compile.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_mean_test_runtime.cpp
+++ b/test/ngs/alea/ngs_alea_mean_test_runtime.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_next.cpp
+++ b/test/ngs/alea/ngs_alea_next.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_stream_test_compile.cpp
+++ b/test/ngs/alea/ngs_alea_stream_test_compile.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_stream_test_runtime.cpp
+++ b/test/ngs/alea/ngs_alea_stream_test_runtime.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_value_type_test.cpp
+++ b/test/ngs/alea/ngs_alea_value_type_test.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_weight_type_test.cpp
+++ b/test/ngs/alea/ngs_alea_weight_type_test.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_wrapper_test_compile.cpp
+++ b/test/ngs/alea/ngs_alea_wrapper_test_compile.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/alea/ngs_alea_wrapper_test_runtime.cpp
+++ b/test/ngs/alea/ngs_alea_wrapper_test_runtime.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2011 - 2012 by Mario Koenz <mkoenz@ethz.ch>                       *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/ngs_hash.cpp
+++ b/test/ngs/ngs_hash.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/ngs_hdf5.cpp
+++ b/test/ngs/ngs_hdf5.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/params/assign.cpp
+++ b/test/ngs/params/assign.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/params/default.cpp
+++ b/test/ngs/params/default.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/params/ordering.cpp
+++ b/test/ngs/params/ordering.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/params/stream.cpp
+++ b/test/ngs/params/stream.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/params/todo.cpp
+++ b/test/ngs/params/todo.cpp
@@ -7,23 +7,8 @@
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                              Matthias Troyer <troyer@comp-phys.org>             *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/scheduler/sum_mpi.cpp
+++ b/test/ngs/scheduler/sum_mpi.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/ngs/scheduler/sum_single.cpp
+++ b/test/ngs/scheduler/sum_single.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/numeric/accumulate_if.C
+++ b/test/numeric/accumulate_if.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/numeric/matrix_algorithms.C
+++ b/test/numeric/matrix_algorithms.C
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010        by Tim Ewart <timothee.ewart@unige.ch>                 *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/numeric/matrix_column_view.C
+++ b/test/numeric/matrix_column_view.C
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #include "matrix_unit_tests.hpp"

--- a/test/numeric/matrix_deprecated_hdf5_format_test.C
+++ b/test/numeric/matrix_deprecated_hdf5_format_test.C
@@ -7,23 +7,8 @@
  * Copyright (C) 2013        by Michele Dolfi <dolfim@phys.ethz.ch>,               *
  *                              Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/numeric/matrix_hdf5.C
+++ b/test/numeric/matrix_hdf5.C
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010        by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/numeric/matrix_kron.C
+++ b/test/numeric/matrix_kron.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2026 by the ALPS collaboration
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/numeric/matrix_transpose_view.C
+++ b/test/numeric/matrix_transpose_view.C
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>                          *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #include "matrix_unit_tests.hpp"

--- a/test/numeric/matrix_unit_tests.C
+++ b/test/numeric/matrix_unit_tests.C
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010        by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/numeric/matrix_unit_tests.hpp
+++ b/test/numeric/matrix_unit_tests.hpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010        by Andreas Hehn <hehn@phys.ethz.ch>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/numeric/real_tests.C
+++ b/test/numeric/real_tests.C
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2012        by Michele Dolfi <dolfim@phys.ethz.ch>                *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/test/numeric/vector_functions.C
+++ b/test/numeric/vector_functions.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/numeric/vector_valarray_conversion.C
+++ b/test/numeric/vector_valarray_conversion.C
@@ -7,23 +7,8 @@
 * Copyright (C) 1994-2010 by Ping Nang Ma <pingnang@itp.phys.ethz.ch>,
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/osiris/boostdump.C
+++ b/test/osiris/boostdump.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/osiris/boostdump2.C
+++ b/test/osiris/boostdump2.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/osiris/boostdump3.C
+++ b/test/osiris/boostdump3.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/osiris/boostdump4.C
+++ b/test/osiris/boostdump4.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2005 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/osiris/os.C
+++ b/test/osiris/os.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/osiris/sizeof.C
+++ b/test/osiris/sizeof.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/osiris/xdrdump.C
+++ b/test/osiris/xdrdump.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/osiris/xdrdump2.C
+++ b/test/osiris/xdrdump2.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/expression.C
+++ b/test/parameter/expression.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/expression2.C
+++ b/test/parameter/expression2.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/flatten.C
+++ b/test/parameter/flatten.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2002 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/parameter.C
+++ b/test/parameter/parameter.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/parameterlist.C
+++ b/test/parameter/parameterlist.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2009 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/parameterlist_xml.C
+++ b/test/parameter/parameterlist_xml.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/parameters.C
+++ b/test/parameter/parameters.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/parameters_hdf5.C
+++ b/test/parameter/parameters_hdf5.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/parameters_mpi.C
+++ b/test/parameter/parameters_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parameter/parameters_xml.C
+++ b/test/parameter/parameters_xml.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2006 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/clone_info.C
+++ b/test/parapack/clone_info.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/clone_mpi.C
+++ b/test/parapack/clone_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/clone_phase.C
+++ b/test/parapack/clone_phase.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/clone_timer.C
+++ b/test/parapack/clone_timer.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/collect_mpi.C
+++ b/test/parapack/collect_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2005-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/comm_mpi.C
+++ b/test/parapack/comm_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2005-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/exmc_optimize.C
+++ b/test/parapack/exmc_optimize.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/exp_number.C
+++ b/test/parapack/exp_number.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/filelock_mpi.C
+++ b/test/parapack/filelock_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/footprint.C
+++ b/test/parapack/footprint.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/halt_mpi.C
+++ b/test/parapack/halt_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/id2string.C
+++ b/test/parapack/id2string.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/info_test.C
+++ b/test/parapack/info_test.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/info_test_mpi.C
+++ b/test/parapack/info_test_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/integer_range.C
+++ b/test/parapack/integer_range.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2005-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/linear_regression.C
+++ b/test/parapack/linear_regression.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2011 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/merge.C
+++ b/test/parapack/merge.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/percentage.C
+++ b/test/parapack/percentage.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2005-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/process_mpi.C
+++ b/test/parapack/process_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/temperature_scan.C
+++ b/test/parapack/temperature_scan.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/time.C
+++ b/test/parapack/time.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/version.C
+++ b/test/parapack/version.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/wl_weight.C
+++ b/test/parapack/wl_weight.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parapack/worker_mpi.C
+++ b/test/parapack/worker_mpi.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2008 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parser/xmlhandler.C
+++ b/test/parser/xmlhandler.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2001-2003 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parser/xmlparser.C
+++ b/test/parser/xmlparser.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/parser/xmlstream.C
+++ b/test/parser/xmlstream.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2001-2006 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/pyalps/hlist_test.py
+++ b/test/pyalps/hlist_test.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Ping Nang Ma
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 from pyalps.hlist import HList

--- a/test/pyalps/loadobs.cpp
+++ b/test/pyalps/loadobs.cpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Lukas Gamper <gamperl -at- gmail.com>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/pyalps/loadobs.py
+++ b/test/pyalps/loadobs.py
@@ -8,22 +8,8 @@ from __future__ import print_function
 # Copyright (C) 2010 by Lukas Gamper <gamperl@gmail.com>
 #                       Matthias Troyer <troyer@itp.phys.ethz.ch>
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/test/pyalps/mcanalyze.py
+++ b/test/pyalps/mcanalyze.py
@@ -8,22 +8,8 @@ from __future__ import print_function
 # Copyright (C) 2010 by Lukas Gamper <gamperl@gmail.com>
 #                       Matthias Troyer <troyer@itp.phys.ethz.ch>
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/test/pyalps/mcdata_test.py
+++ b/test/pyalps/mcdata_test.py
@@ -9,22 +9,8 @@ from __future__ import print_function
 #                       Lukas Gamper <gamperl@gmail.com>
 #                       Matthias Troyer <troyer@itp.phys.ethz.ch>
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 #
 # ****************************************************************************
 

--- a/test/pyalps/numpylarge.py
+++ b/test/pyalps/numpylarge.py
@@ -7,22 +7,8 @@ from __future__ import print_function
  #                                                                                 #
  # Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  #                                                                                 #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/test/pyalps/pyhdf5_test.py
+++ b/test/pyalps/pyhdf5_test.py
@@ -8,22 +8,8 @@ from __future__ import print_function
 # Copyright (C) 2010 by Lukas Gamper <gamperl@gmail.com>
 #                       Matthias Troyer <troyer@itp.phys.ethz.ch>
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/test/pyalps/pyhdf5io_test.py
+++ b/test/pyalps/pyhdf5io_test.py
@@ -8,22 +8,8 @@ from __future__ import print_function
  # Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   #
  #               2016 - 2016 by Michele Dolfi <dolfim@phys.ethz.ch>                #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  #                                                                                 #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/test/pyalps/pyioarchive.py
+++ b/test/pyalps/pyioarchive.py
@@ -6,22 +6,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  #                                                                                 #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/test/pyalps/pyparams_test.py
+++ b/test/pyalps/pyparams_test.py
@@ -7,22 +7,8 @@ from __future__ import print_function
  #                                                                                 #
  # Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  #                                                                                 #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/test/random/random_choice.C
+++ b/test/random/random_choice.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/random/uniform_on_sphere_n.C
+++ b/test/random/uniform_on_sphere_n.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2012 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/utility/bitops.cpp
+++ b/test/utility/bitops.cpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2013 by Andreas Hehn <hehn@phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/test/utility/vmusage.cpp
+++ b/test/utility/vmusage.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2010-2012 by Haruhiko Matsuo <halm@looper.t.u-tokyo.ac.jp>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/alea/mcanalyze_tools.hpp
+++ b/tool/alea/mcanalyze_tools.hpp
@@ -6,23 +6,8 @@
 *                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Maximilian Poprawe <poprawem@ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/alea/mcanalyze_tools.ipp
+++ b/tool/alea/mcanalyze_tools.ipp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tool/alea/mcanalyze_tools.py
+++ b/tool/alea/mcanalyze_tools.py
@@ -7,23 +7,8 @@ from __future__ import print_function
 #*                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 #*                            Maximilian Poprawe <poprawem@ethz.ch>
 #*
-#* Permission is hereby granted, free of charge, to any person obtaining
-#* a copy of this software and associated documentation files (the “Software”),
-#* to deal in the Software without restriction, including without limitation
-#* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-#* and/or sell copies of the Software, and to permit persons to whom the
-#* Software is furnished to do so, subject to the following conditions:
-#*
-#* The above copyright notice and this permission notice shall be included
-#* in all copies or substantial portions of the Software.
-#*
-#* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-#* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-#* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#* DEALINGS IN THE SOFTWARE.
+#* ALPS Project: https://alps.comp-phys.org/
+#* SPDX-License-Identifier: MIT
 #*
 #*****************************************************************************/
 

--- a/tool/alea/mean.cpp
+++ b/tool/alea/mean.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tool/alea/mean.py
+++ b/tool/alea/mean.py
@@ -7,23 +7,8 @@
 #*                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 #*                            Maximilian Poprawe <poprawem@ethz.ch>
 #*
-#* Permission is hereby granted, free of charge, to any person obtaining
-#* a copy of this software and associated documentation files (the “Software”),
-#* to deal in the Software without restriction, including without limitation
-#* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-#* and/or sell copies of the Software, and to permit persons to whom the
-#* Software is furnished to do so, subject to the following conditions:
-#*
-#* The above copyright notice and this permission notice shall be included
-#* in all copies or substantial portions of the Software.
-#*
-#* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-#* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-#* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#* DEALINGS IN THE SOFTWARE.
+#* ALPS Project: https://alps.comp-phys.org/
+#* SPDX-License-Identifier: MIT
 #*
 #*****************************************************************************/
 

--- a/tool/alea/variance.cpp
+++ b/tool/alea/variance.cpp
@@ -6,23 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2011 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * Permission is hereby granted, free of charge, to any person obtaining           *
- * a copy of this software and associated documentation files (the “Software”),    *
- * to deal in the Software without restriction, including without limitation       *
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,        *
- * and/or sell copies of the Software, and to permit persons to whom the           *
- * Software is furnished to do so, subject to the following conditions:            *
- *                                                                                 *
- * The above copyright notice and this permission notice shall be included         *
- * in all copies or substantial portions of the Software.                          *
- *                                                                                 *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS         *
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         *
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER             *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tool/alea/variance.py
+++ b/tool/alea/variance.py
@@ -7,23 +7,8 @@
 #*                            Matthias Troyer <troyer@itp.phys.ethz.ch>,
 #*                            Maximilian Poprawe <poprawem@ethz.ch>
 #*
-#* Permission is hereby granted, free of charge, to any person obtaining
-#* a copy of this software and associated documentation files (the “Software”),
-#* to deal in the Software without restriction, including without limitation
-#* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-#* and/or sell copies of the Software, and to permit persons to whom the
-#* Software is furnished to do so, subject to the following conditions:
-#*
-#* The above copyright notice and this permission notice shall be included
-#* in all copies or substantial portions of the Software.
-#*
-#* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-#* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-#* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#* DEALINGS IN THE SOFTWARE.
+#* ALPS Project: https://alps.comp-phys.org/
+#* SPDX-License-Identifier: MIT
 #*
 #*****************************************************************************/
 

--- a/tool/archive.cpp
+++ b/tool/archive.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2005-2008 by Lukas Gamper <mistral@student.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_index.cpp
+++ b/tool/archive_index.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2006-2013 by Lukas Gamper <mistral@student.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_index.hpp
+++ b/tool/archive_index.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2005-2009 by Lukas Gamper <mistral@student.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_node.cpp
+++ b/tool/archive_node.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2005-2008 by Lukas Gamper <mistral@student.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_node.hpp
+++ b/tool/archive_node.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2005-2008 by Lukas Gamper <mistral@student.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_plot.cpp
+++ b/tool/archive_plot.cpp
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Niall Moran <nmoran@thphys.nuim.ie>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_plot.hpp
+++ b/tool/archive_plot.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2005 by Lukas Gamper <mistral@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_sqlite.cpp
+++ b/tool/archive_sqlite.cpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2005-2008 by Lukas Gamper <mistral@student.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_sqlite.hpp
+++ b/tool/archive_sqlite.hpp
@@ -7,23 +7,8 @@
 * Copyright (C) 2005-2006 by Lukas Gamper <mistral@student.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_xml.cpp
+++ b/tool/archive_xml.cpp
@@ -8,23 +8,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>,
 *                            Niall Moran <nmoran@thphys.nuim.ie>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/archive_xml.hpp
+++ b/tool/archive_xml.hpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2005 by Lukas Gamper <mistral@student.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/compactrun.C
+++ b/tool/compactrun.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/config.py.in
+++ b/tool/config.py.in
@@ -6,22 +6,8 @@
 #
 # Copyright (C) 2006-2009 by Synge Todo <wistaria@comp-phys.org>
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-# 
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 #
 ##############################################################################
 

--- a/tool/convert2xml.C
+++ b/tool/convert2xml.C
@@ -8,23 +8,8 @@
 *                            Simon Trebst <trebst@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/default_model.hpp
+++ b/tool/default_model.hpp
@@ -6,22 +6,8 @@
 *                       Thomas Pruschke <pruschke@comp-phys.org>
 *                       Matthias Troyer <troyer@comp-phys.org>
 *
-* This software is part of the ALPS Applications, published under the ALPS
-* Application License; you can use, redistribute it and/or modify it under
-* the terms of the license, either version 1 or (at your option) any later
-* version.
-* 
-* You should have received a copy of the ALPS Application License along with
-* the ALPS Applications; see the file LICENSE.txt. If not, the license is also
-* available from http://alps.comp-phys.org/.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/lattice2xml.C
+++ b/tool/lattice2xml.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2006-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/license.py
+++ b/tool/license.py
@@ -6,22 +6,8 @@
 #
 # Copyright (C) 2006-2009 by Synge Todo <wistaria@comp-phys.org>
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-# 
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 #
 ##############################################################################
 

--- a/tool/maxent.cpp
+++ b/tool/maxent.cpp
@@ -6,22 +6,8 @@
 *                       Thomas Pruschke <pruschke@comp-phys.org>
 *                       Matthias Troyer <troyer@comp-phys.org>
 *
-* This software is part of the ALPS Applications, published under the ALPS
-* Application License; you can use, redistribute it and/or modify it under
-* the terms of the license, either version 1 or (at your option) any later
-* version.
-* 
-* You should have received a copy of the ALPS Application License along with
-* the ALPS Applications; see the file LICENSE.txt. If not, the license is also
-* available from http://alps.comp-phys.org/.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/maxent.hpp
+++ b/tool/maxent.hpp
@@ -7,22 +7,8 @@
 *                       Matthias Troyer <troyer@comp-phys.org>
 *               2011 by Emanuel Gull <gull@phys.columbia.edu>
 *
-* This software is part of the ALPS Applications, published under the ALPS
-* Application License; you can use, redistribute it and/or modify it under
-* the terms of the license, either version 1 or (at your option) any later
-* version.
-* 
-* You should have received a copy of the ALPS Application License along with
-* the ALPS Applications; see the file LICENSE.txt. If not, the license is also
-* available from http://alps.comp-phys.org/.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/maxent_helper.cpp
+++ b/tool/maxent_helper.cpp
@@ -7,22 +7,8 @@
  *                       Matthias Troyer <troyer@comp-phys.org>
  *               2011 by Emanuel Gull  <gull@phys.columbia.edu>
  *
- * This software is part of the ALPS Applications, published under the ALPS
- * Application License; you can use, redistribute it and/or modify it under
- * the terms of the license, either version 1 or (at your option) any later
- * version.
- * 
- * You should have received a copy of the ALPS Application License along with
- * the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- * available from http://alps.comp-phys.org/.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- * DEALINGS IN THE SOFTWARE.
+ * ALPS Project: https://alps.comp-phys.org/
+ * SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/tool/maxent_parms.cpp
+++ b/tool/maxent_parms.cpp
@@ -6,22 +6,8 @@
  *                       Thomas Pruschke <pruschke@comp-phys.org>
  *                       Matthias Troyer <troyer@comp-phys.org>
  *
- * This software is part of the ALPS Applications, published under the ALPS
- * Application License; you can use, redistribute it and/or modify it under
- * the terms of the license, either version 1 or (at your option) any later
- * version.
- * 
- * You should have received a copy of the ALPS Application License along with
- * the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- * available from http://alps.comp-phys.org/.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- * DEALINGS IN THE SOFTWARE.
+ * ALPS Project: https://alps.comp-phys.org/
+ * SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/tool/maxent_parms.hpp
+++ b/tool/maxent_parms.hpp
@@ -6,22 +6,8 @@
 *                       Thomas Pruschke <pruschke@comp-phys.org>
 *                       Matthias Troyer <troyer@comp-phys.org>
 *
-* This software is part of the ALPS Applications, published under the ALPS
-* Application License; you can use, redistribute it and/or modify it under
-* the terms of the license, either version 1 or (at your option) any later
-* version.
-* 
-* You should have received a copy of the ALPS Application License along with
-* the ALPS Applications; see the file LICENSE.txt. If not, the license is also
-* available from http://alps.comp-phys.org/.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-* FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-* SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-* FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/maxent_simulation.cpp
+++ b/tool/maxent_simulation.cpp
@@ -7,22 +7,8 @@
  *                       Matthias Troyer <troyer@comp-phys.org>
  *               2012 by Emanuel Gull <gull@pks.mpg.de>
  *
- * This software is part of the ALPS Applications, published under the ALPS
- * Application License; you can use, redistribute it and/or modify it under
- * the terms of the license, either version 1 or (at your option) any later
- * version.
- * 
- * You should have received a copy of the ALPS Application License along with
- * the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- * available from http://alps.comp-phys.org/.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- * DEALINGS IN THE SOFTWARE.
+ * ALPS Project: https://alps.comp-phys.org/
+ * SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/tool/p2h5.cpp
+++ b/tool/p2h5.cpp
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2010 by Lukas Gamper <gamperl -at- gmail.com>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/parameter2hdf5.C
+++ b/tool/parameter2hdf5.C
@@ -9,23 +9,8 @@
 *                            Synge Todo <wistaria@comp-phys.org>
 *                            Lukas Gamper <gamperl@gmail.com>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/parameter2xml.C
+++ b/tool/parameter2xml.C
@@ -8,23 +8,8 @@
 *                            Simon Trebst <trebst@comp-phys.org>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/pconfig.C
+++ b/tool/pconfig.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2002-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/pevaluate.C
+++ b/tool/pevaluate.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/poutput.C
+++ b/tool/poutput.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2010 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/preview.py
+++ b/tool/preview.py
@@ -6,22 +6,8 @@
 #
 # Copyright (C) 2006-2009 by Synge Todo <wistaria@comp-phys.org>
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-# 
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 #
 ##############################################################################
 

--- a/tool/printgraph.C
+++ b/tool/printgraph.C
@@ -7,23 +7,8 @@
 * Copyright (C) 2001-2003 by Matthias Troyer <troyer@itp.phys.ethz.ch>,
 *                            Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/snap2vtk.C
+++ b/tool/snap2vtk.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 2012-2015 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/txt2archive.C
+++ b/tool/txt2archive.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2009 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tool/xml2archive.C
+++ b/tool/xml2archive.C
@@ -6,23 +6,8 @@
 *
 * Copyright (C) 1997-2013 by Synge Todo <wistaria@comp-phys.org>
 *
-* Permission is hereby granted, free of charge, to any person obtaining
-* a copy of this software and associated documentation files (the “Software”),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included
-* in all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
+* ALPS Project: https://alps.comp-phys.org/
+* SPDX-License-Identifier: MIT
 *
 *****************************************************************************/
 

--- a/tutorials/code-01-python/ising-skeleton.py
+++ b/tutorials/code-01-python/ising-skeleton.py
@@ -9,22 +9,8 @@ from __future__ import print_function
 #                            Jan Gukelberger
 #                            Brigitte Surer
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/code-01-python/solution/ising.py
+++ b/tutorials/code-01-python/solution/ising.py
@@ -8,22 +8,8 @@
 #                            Jan Gukelberger
 #                            Brigitte Surer
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/code-01-python/solution/ising_binder.py
+++ b/tutorials/code-01-python/solution/ising_binder.py
@@ -8,22 +8,8 @@
 #                            Jan Gukelberger
 #                            Brigitte Surer
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/code-01-python/solution/run.py
+++ b/tutorials/code-01-python/solution/run.py
@@ -8,22 +8,8 @@
 #                            Jan Gukelberger
 #                            Brigitte Surer
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/code-02-c++/ising-skeleton.cpp
+++ b/tutorials/code-02-c++/ising-skeleton.cpp
@@ -7,22 +7,8 @@
  * Copyright (C) 2003 by Brigitte Surer
  *                       and Jan Gukelberger
  *
- * This software is part of the ALPS libraries, published under the ALPS
- * Library License; you can use, redistribute it and/or modify it under
- * the terms of the license, either version 1 or (at your option) any later
- * version.
- * 
- * You should have received a copy of the ALPS Library License along with
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
- * available from http://alps.comp-phys.org/.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- * DEALINGS IN THE SOFTWARE.
+ * ALPS Project: https://alps.comp-phys.org/
+ * SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/tutorials/code-02-c++/solution/ising.cpp
+++ b/tutorials/code-02-c++/solution/ising.cpp
@@ -7,22 +7,8 @@
  * Copyright (C) 2003 by Brigitte Surer
  *                       and Jan Gukelberger
  *
- * This software is part of the ALPS libraries, published under the ALPS
- * Library License; you can use, redistribute it and/or modify it under
- * the terms of the license, either version 1 or (at your option) any later
- * version.
- * 
- * You should have received a copy of the ALPS Library License along with
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
- * available from http://alps.comp-phys.org/.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- * DEALINGS IN THE SOFTWARE.
+ * ALPS Project: https://alps.comp-phys.org/
+ * SPDX-License-Identifier: MIT
  *
  *****************************************************************************/
 

--- a/tutorials/code-06-mcmain-c++/ising.cpp
+++ b/tutorials/code-06-mcmain-c++/ising.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-06-mcmain-c++/ising.hpp
+++ b/tutorials/code-06-mcmain-c++/ising.hpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-06-mcmain-c++/main.cpp
+++ b/tutorials/code-06-mcmain-c++/main.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-07-mcmain-mcbase/export.cpp
+++ b/tutorials/code-07-mcmain-mcbase/export.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-07-mcmain-mcbase/export.py
+++ b/tutorials/code-07-mcmain-mcbase/export.py
@@ -6,22 +6,8 @@ from __future__ import print_function
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.hdf5 as hdf5

--- a/tutorials/code-07-mcmain-mcbase/heisenberg/1d_lattice/single.cpp
+++ b/tutorials/code-07-mcmain-mcbase/heisenberg/1d_lattice/single.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-07-mcmain-mcbase/heisenberg/nd_lattice/single.cpp
+++ b/tutorials/code-07-mcmain-mcbase/heisenberg/nd_lattice/single.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-07-mcmain-mcbase/heisenberg/o_n_model/heisenberg.cpp
+++ b/tutorials/code-07-mcmain-mcbase/heisenberg/o_n_model/heisenberg.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-07-mcmain-mcbase/ising.cpp
+++ b/tutorials/code-07-mcmain-mcbase/ising.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-07-mcmain-mcbase/ising.hpp
+++ b/tutorials/code-07-mcmain-mcbase/ising.hpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-07-mcmain-mcbase/mpi.cpp
+++ b/tutorials/code-07-mcmain-mcbase/mpi.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-07-mcmain-mcbase/mpi_pscan.cpp
+++ b/tutorials/code-07-mcmain-mcbase/mpi_pscan.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-07-mcmain-mcbase/single.cpp
+++ b/tutorials/code-07-mcmain-mcbase/single.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/code-08-mcmain-python/ising.py
+++ b/tutorials/code-08-mcmain-python/ising.py
@@ -5,22 +5,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.hdf5 as hdf5

--- a/tutorials/code-08-mcmain-python/main.py
+++ b/tutorials/code-08-mcmain-python/main.py
@@ -6,22 +6,8 @@ from __future__ import print_function
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.hdf5 as hdf5

--- a/tutorials/code-09-mcmain-python-hybrid/ising.py
+++ b/tutorials/code-09-mcmain-python-hybrid/ising.py
@@ -5,22 +5,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.ngs as ngs

--- a/tutorials/code-09-mcmain-python-hybrid/main.py
+++ b/tutorials/code-09-mcmain-python-hybrid/main.py
@@ -6,22 +6,8 @@ from __future__ import print_function
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.hdf5 as hdf5

--- a/tutorials/dmft-02-hybridization/tutorial2.py
+++ b/tutorials/dmft-02-hybridization/tutorial2.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-02-hybridization/tutorial2_long.py
+++ b/tutorials/dmft-02-hybridization/tutorial2_long.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-02-hybridization/tutorial2eval.py
+++ b/tutorials/dmft-02-hybridization/tutorial2eval.py
@@ -6,22 +6,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-03-interaction/tutorial3.py
+++ b/tutorials/dmft-03-interaction/tutorial3.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-03-interaction/tutorial3_long.py
+++ b/tutorials/dmft-03-interaction/tutorial3_long.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-03-interaction/tutorial3eval.py
+++ b/tutorials/dmft-03-interaction/tutorial3eval.py
@@ -6,22 +6,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-04-mott/tutorial4a.py
+++ b/tutorials/dmft-04-mott/tutorial4a.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-04-mott/tutorial4b.py
+++ b/tutorials/dmft-04-mott/tutorial4b.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-05-osmt/tutorial5a.py
+++ b/tutorials/dmft-05-osmt/tutorial5a.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-05-osmt/tutorial5b.py
+++ b/tutorials/dmft-05-osmt/tutorial5b.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-06-paramagnet/hyb/tutorial6a.py
+++ b/tutorials/dmft-06-paramagnet/hyb/tutorial6a.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-06-paramagnet/int/tutorial6b.py
+++ b/tutorials/dmft-06-paramagnet/int/tutorial6b.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010 by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-07-hirschfye/tutorial7.py
+++ b/tutorials/dmft-07-hirschfye/tutorial7.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-07-hirschfye/tutorial7_long.py
+++ b/tutorials/dmft-07-hirschfye/tutorial7_long.py
@@ -6,22 +6,8 @@
 # Copyright (C) 2010      by Brigitte Surer <surerb@phys.ethz.ch> 
 #               2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-07-hirschfye/tutorial7eval.py
+++ b/tutorials/dmft-07-hirschfye/tutorial7eval.py
@@ -6,22 +6,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-08-lattices/DOS/DOS_Bethe.py
+++ b/tutorials/dmft-08-lattices/DOS/DOS_Bethe.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2012 by Jakub Imriska <jimriska@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-08-lattices/DOS/DOS_Cubic.py
+++ b/tutorials/dmft-08-lattices/DOS/DOS_Cubic.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2012 by Jakub Imriska <jimriska@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-08-lattices/DOS/DOS_Hexagonal.py
+++ b/tutorials/dmft-08-lattices/DOS/DOS_Hexagonal.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2012 by Jakub Imriska <jimriska@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-08-lattices/DOS/DOS_Square.py
+++ b/tutorials/dmft-08-lattices/DOS/DOS_Square.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2012 by Jakub Imriska <jimriska@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-08-lattices/tutorial8a.py
+++ b/tutorials/dmft-08-lattices/tutorial8a.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmft-08-lattices/tutorial8b.py
+++ b/tutorials/dmft-08-lattices/tutorial8b.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2012-2013 by Jakub Imriska  <jimriska@phys.ethz.ch>
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-03-ground-state-energies/build_lattice.py
+++ b/tutorials/dmrg-03-ground-state-energies/build_lattice.py
@@ -9,22 +9,8 @@
 #                            Jan Gukelberger
 #                            Adrian Feiguin
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-03-ground-state-energies/spin_one.py
+++ b/tutorials/dmrg-03-ground-state-energies/spin_one.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-03-ground-state-energies/spin_one_half.py
+++ b/tutorials/dmrg-03-ground-state-energies/spin_one_half.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-03-ground-state-energies/spin_one_half_multiple.py
+++ b/tutorials/dmrg-03-ground-state-energies/spin_one_half_multiple.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-03-ground-state-energies/spin_one_multiple.py
+++ b/tutorials/dmrg-03-ground-state-energies/spin_one_multiple.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-04-gaps/spin_one_gap.py
+++ b/tutorials/dmrg-04-gaps/spin_one_gap.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2025 by ALPS Collaboration
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-04-gaps/spin_one_gap_multiple.py
+++ b/tutorials/dmrg-04-gaps/spin_one_gap_multiple.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2025 by ALPS Collaboration
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-04-gaps/spin_one_half_gap.py
+++ b/tutorials/dmrg-04-gaps/spin_one_half_gap.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-04-gaps/spin_one_half_gap_multiple.py
+++ b/tutorials/dmrg-04-gaps/spin_one_half_gap_multiple.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2025 by ALPS Collaboration
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-04-gaps/spin_one_half_triplet.py
+++ b/tutorials/dmrg-04-gaps/spin_one_half_triplet.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-04-gaps/spin_one_triplet.py
+++ b/tutorials/dmrg-04-gaps/spin_one_triplet.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2025 by ALPS Collaboration
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-05-local-observables/build_lattice.py
+++ b/tutorials/dmrg-05-local-observables/build_lattice.py
@@ -9,22 +9,8 @@
 #                            Jan Gukelberger
 #                            Adrian Feiguin
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-05-local-observables/spin_one.py
+++ b/tutorials/dmrg-05-local-observables/spin_one.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-05-local-observables/spin_one_capped.py
+++ b/tutorials/dmrg-05-local-observables/spin_one_capped.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-05-local-observables/spin_one_half.py
+++ b/tutorials/dmrg-05-local-observables/spin_one_half.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-05-local-observables/spin_one_uniform.py
+++ b/tutorials/dmrg-05-local-observables/spin_one_uniform.py
@@ -6,22 +6,8 @@
 #
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch>
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 #
 # ****************************************************************************
 

--- a/tutorials/dmrg-06-correlations/spin_one.py
+++ b/tutorials/dmrg-06-correlations/spin_one.py
@@ -7,22 +7,8 @@ from __future__ import division
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dmrg-06-correlations/spin_one_half.py
+++ b/tutorials/dmrg-06-correlations/spin_one_half.py
@@ -7,22 +7,8 @@ from __future__ import division
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dwa-01-bosons/tutorial1a.py
+++ b/tutorials/dwa-01-bosons/tutorial1a.py
@@ -7,22 +7,8 @@
 # Copyright (C) 2013 by Matthias Troyer <troyer@phys.ethz.ch>,
 #                       Ping Nang Ma    <pingnang@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dwa-01-bosons/tutorial1b.py
+++ b/tutorials/dwa-01-bosons/tutorial1b.py
@@ -7,22 +7,8 @@
 # Copyright (C) 2013 by Matthias Troyer <troyer@phys.ethz.ch>,
 #                       Ping Nang Ma    <pingnang@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dwa-02-density-profile/tutorial2a.py
+++ b/tutorials/dwa-02-density-profile/tutorial2a.py
@@ -7,22 +7,8 @@
 # Copyright (C) 2013 by Matthias Troyer <troyer@phys.ethz.ch>,
 #                       Ping Nang Ma    <pingnang@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/dwa-02-density-profile/tutorial2b.py
+++ b/tutorials/dwa-02-density-profile/tutorial2b.py
@@ -7,22 +7,8 @@
 # Copyright (C) 2013 by Matthias Troyer <troyer@phys.ethz.ch>,
 #                       Ping Nang Ma    <pingnang@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-01-sparsediag/tutorial1a.py
+++ b/tutorials/ed-01-sparsediag/tutorial1a.py
@@ -6,22 +6,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-02-gaps/tutorial2a.py
+++ b/tutorials/ed-02-gaps/tutorial2a.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-02-gaps/tutorial2b.py
+++ b/tutorials/ed-02-gaps/tutorial2b.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-02-gaps/tutorial2c.py
+++ b/tutorials/ed-02-gaps/tutorial2c.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-03-1dspectra/chain.py
+++ b/tutorials/ed-03-1dspectra/chain.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-03-1dspectra/dimers.py
+++ b/tutorials/ed-03-1dspectra/dimers.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-03-1dspectra/ladder.py
+++ b/tutorials/ed-03-1dspectra/ladder.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-04-criticality/heisenberg.py
+++ b/tutorials/ed-04-criticality/heisenberg.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-04-criticality/ising.py
+++ b/tutorials/ed-04-criticality/ising.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-05-nnn-chain/nnn-crit-pt.py
+++ b/tutorials/ed-05-nnn-chain/nnn-crit-pt.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-05-nnn-chain/nnn-heisenberg.py
+++ b/tutorials/ed-05-nnn-chain/nnn-heisenberg.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-06-fulldiag/tutorial6a.py
+++ b/tutorials/ed-06-fulldiag/tutorial6a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-06-fulldiag/tutorial6b.py
+++ b/tutorials/ed-06-fulldiag/tutorial6b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-06-fulldiag/tutorial6c.py
+++ b/tutorials/ed-06-fulldiag/tutorial6c.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ed-06-fulldiag/tutorial6d.py
+++ b/tutorials/ed-06-fulldiag/tutorial6d.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/hybridization-01-python/tutorial1.py
+++ b/tutorials/hybridization-01-python/tutorial1.py
@@ -7,22 +7,8 @@
  # Copyright (C) 2012 by Hartmut Hafermann <hafermann@cpht.polytechnique.fr>
  #
  #
- # This software is part of the ALPS Applications, published under the ALPS
- # Application License; you can use, redistribute it and/or modify it under
- # the terms of the license, either version 1 or (at your option) any later
- # version.
- # 
- # You should have received a copy of the ALPS Application License along with
- # the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- # available from http://alps.comp-phys.org/.
- #
- # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- # DEALINGS IN THE SOFTWARE.
+ # ALPS Project: https://alps.comp-phys.org/
+ # SPDX-License-Identifier: MIT
  #
  #############################################################################/
 

--- a/tutorials/hybridization-02-kondo/tutorial2.py
+++ b/tutorials/hybridization-02-kondo/tutorial2.py
@@ -8,22 +8,8 @@ from __future__ import print_function
  # Copyright (C) 2012 by Hartmut Hafermann <hafermann@cpht.polytechnique.fr>
  #
  #
- # This software is part of the ALPS Applications, published under the ALPS
- # Application License; you can use, redistribute it and/or modify it under
- # the terms of the license, either version 1 or (at your option) any later
- # version.
- # 
- # You should have received a copy of the ALPS Application License along with
- # the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- # available from http://alps.comp-phys.org/.
- #
- # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- # DEALINGS IN THE SOFTWARE.
+ # ALPS Project: https://alps.comp-phys.org/
+ # SPDX-License-Identifier: MIT
  #
  #############################################################################/
 

--- a/tutorials/hybridization-03-retarded-interaction/tutorial3.py
+++ b/tutorials/hybridization-03-retarded-interaction/tutorial3.py
@@ -8,22 +8,8 @@ from __future__ import print_function
  # Copyright (C) 2012 by Hartmut Hafermann <hafermann@cpht.polytechnique.fr>
  #
  #
- # This software is part of the ALPS Applications, published under the ALPS
- # Application License; you can use, redistribute it and/or modify it under
- # the terms of the license, either version 1 or (at your option) any later
- # version.
- # 
- # You should have received a copy of the ALPS Application License along with
- # the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- # available from http://alps.comp-phys.org/.
- #
- # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- # DEALINGS IN THE SOFTWARE.
+ # ALPS Project: https://alps.comp-phys.org/
+ # SPDX-License-Identifier: MIT
  #
  #############################################################################/
 

--- a/tutorials/hybridization-04-spinfreezing/tutorial4a.py
+++ b/tutorials/hybridization-04-spinfreezing/tutorial4a.py
@@ -8,22 +8,8 @@ from __future__ import print_function
  # Copyright (C) 2012 by Hartmut Hafermann <hafermann@cpht.polytechnique.fr>
  #
  #
- # This software is part of the ALPS Applications, published under the ALPS
- # Application License; you can use, redistribute it and/or modify it under
- # the terms of the license, either version 1 or (at your option) any later
- # version.
- # 
- # You should have received a copy of the ALPS Application License along with
- # the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- # available from http://alps.comp-phys.org/.
- #
- # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- # DEALINGS IN THE SOFTWARE.
+ # ALPS Project: https://alps.comp-phys.org/
+ # SPDX-License-Identifier: MIT
  #
  #############################################################################/
 

--- a/tutorials/hybridization-04-spinfreezing/tutorial4b.py
+++ b/tutorials/hybridization-04-spinfreezing/tutorial4b.py
@@ -8,22 +8,8 @@ from __future__ import print_function
  # Copyright (C) 2012 by Hartmut Hafermann <hafermann@cpht.polytechnique.fr>
  #
  #
- # This software is part of the ALPS Applications, published under the ALPS
- # Application License; you can use, redistribute it and/or modify it under
- # the terms of the license, either version 1 or (at your option) any later
- # version.
- # 
- # You should have received a copy of the ALPS Application License along with
- # the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- # available from http://alps.comp-phys.org/.
- #
- # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- # DEALINGS IN THE SOFTWARE.
+ # ALPS Project: https://alps.comp-phys.org/
+ # SPDX-License-Identifier: MIT
  #
  #############################################################################/
 

--- a/tutorials/hybridization-04-spinfreezing/tutorial4c.py
+++ b/tutorials/hybridization-04-spinfreezing/tutorial4c.py
@@ -7,22 +7,8 @@
  # Copyright (C) 2012 by Hartmut Hafermann <hafermann@cpht.polytechnique.fr>
  #
  #
- # This software is part of the ALPS Applications, published under the ALPS
- # Application License; you can use, redistribute it and/or modify it under
- # the terms of the license, either version 1 or (at your option) any later
- # version.
- # 
- # You should have received a copy of the ALPS Application License along with
- # the ALPS Applications; see the file LICENSE.txt. If not, the license is also
- # available from http://alps.comp-phys.org/.
- #
- # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
- # DEALINGS IN THE SOFTWARE.
+ # ALPS Project: https://alps.comp-phys.org/
+ # SPDX-License-Identifier: MIT
  #
  #############################################################################/
 

--- a/tutorials/intro-01-basics/tutorial-binder.py
+++ b/tutorials/intro-01-basics/tutorial-binder.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/intro-01-basics/tutorial-evaluate.py
+++ b/tutorials/intro-01-basics/tutorial-evaluate.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/intro-01-basics/tutorial-full.py
+++ b/tutorials/intro-01-basics/tutorial-full.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/intro-01-basics/tutorial-gnuplot.py
+++ b/tutorials/intro-01-basics/tutorial-gnuplot.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/intro-01-basics/tutorial-graceplot.py
+++ b/tutorials/intro-01-basics/tutorial-graceplot.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/intro-01-basics/tutorial-magnetization.py
+++ b/tutorials/intro-01-basics/tutorial-magnetization.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/intro-01-basics/tutorial-prepareinput.py
+++ b/tutorials/intro-01-basics/tutorial-prepareinput.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/intro-01-basics/tutorial-runsimulation.py
+++ b/tutorials/intro-01-basics/tutorial-runsimulation.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/intro-01-basics/tutorial-text.py
+++ b/tutorials/intro-01-basics/tutorial-text.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-01-autocorrelations/tutorial1a.py
+++ b/tutorials/mc-01-autocorrelations/tutorial1a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-01-autocorrelations/tutorial1b.py
+++ b/tutorials/mc-01-autocorrelations/tutorial1b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-01b-equilibration-and-convergence/tutorial1a.py
+++ b/tutorials/mc-01b-equilibration-and-convergence/tutorial1a.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 #                       Ping Nang Ma     <pingnang@phys.ethz.ch> 
 #                       Matthias Troyer  <troyer@phys.ethz.ch>    
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 #
 #############################################################################
 

--- a/tutorials/mc-02-susceptibilities/tutorial2a.py
+++ b/tutorials/mc-02-susceptibilities/tutorial2a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-02-susceptibilities/tutorial2b.py
+++ b/tutorials/mc-02-susceptibilities/tutorial2b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-02-susceptibilities/tutorial2c.py
+++ b/tutorials/mc-02-susceptibilities/tutorial2c.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-02-susceptibilities/tutorial2d.py
+++ b/tutorials/mc-02-susceptibilities/tutorial2d.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-02-susceptibilities/tutorial2full.py
+++ b/tutorials/mc-02-susceptibilities/tutorial2full.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-03-magnetization/tutorial3a.py
+++ b/tutorials/mc-03-magnetization/tutorial3a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-03-magnetization/tutorial3b.py
+++ b/tutorials/mc-03-magnetization/tutorial3b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-03-magnetization/tutorial3full.py
+++ b/tutorials/mc-03-magnetization/tutorial3full.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-04-measurements/tutorial4.py
+++ b/tutorials/mc-04-measurements/tutorial4.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-05-bosons/tutorial5a.py
+++ b/tutorials/mc-05-bosons/tutorial5a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-05-bosons/tutorial5b.py
+++ b/tutorials/mc-05-bosons/tutorial5b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-06-qwl/tutorial6a.py
+++ b/tutorials/mc-06-qwl/tutorial6a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-06-qwl/tutorial6b.py
+++ b/tutorials/mc-06-qwl/tutorial6b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-06-qwl/tutorial6c.py
+++ b/tutorials/mc-06-qwl/tutorial6c.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-06-qwl/tutorial6d.py
+++ b/tutorials/mc-06-qwl/tutorial6d.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-07-phase-transition/tutorial7a.py
+++ b/tutorials/mc-07-phase-transition/tutorial7a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Brigitte Surer <surerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-07-phase-transition/tutorial7b.py
+++ b/tutorials/mc-07-phase-transition/tutorial7b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Brigitte Surer <surerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-08-quantum-phase-transition/tutorial8a.py
+++ b/tutorials/mc-08-quantum-phase-transition/tutorial8a.py
@@ -7,22 +7,8 @@ from __future__ import print_function
 # 
 # Copyright (C) 2010 by Brigitte Surer
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-08-quantum-phase-transition/tutorial8b.py
+++ b/tutorials/mc-08-quantum-phase-transition/tutorial8b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Brigitte Surer
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-08-quantum-phase-transition/tutorial8c.py
+++ b/tutorials/mc-08-quantum-phase-transition/tutorial8c.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Brigitte Surer
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-08-quantum-phase-transition/tutorial8d.py
+++ b/tutorials/mc-08-quantum-phase-transition/tutorial8d.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Brigitte Surer
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/mc-09-snapshot/plot9a.py
+++ b/tutorials/mc-09-snapshot/plot9a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2015 by Synge Todo <wistaria@comp-phys.org> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/ngs/1_accumulator_only/ising.cpp
+++ b/tutorials/ngs/1_accumulator_only/ising.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/1_accumulator_only/ising.hpp
+++ b/tutorials/ngs/1_accumulator_only/ising.hpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/1_accumulator_only/main.cpp
+++ b/tutorials/ngs/1_accumulator_only/main.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/2_single_core/ising.cpp
+++ b/tutorials/ngs/2_single_core/ising.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/2_single_core/ising.hpp
+++ b/tutorials/ngs/2_single_core/ising.hpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/2_single_core/main.cpp
+++ b/tutorials/ngs/2_single_core/main.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/3_mpi/ising.cpp
+++ b/tutorials/ngs/3_mpi/ising.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/3_mpi/ising.hpp
+++ b/tutorials/ngs/3_mpi/ising.hpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/3_mpi/main.cpp
+++ b/tutorials/ngs/3_mpi/main.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/4_mpi_pscan/ising.cpp
+++ b/tutorials/ngs/4_mpi_pscan/ising.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/4_mpi_pscan/ising.hpp
+++ b/tutorials/ngs/4_mpi_pscan/ising.hpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/4_mpi_pscan/main.cpp
+++ b/tutorials/ngs/4_mpi_pscan/main.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/5_export_python/export2py.cpp
+++ b/tutorials/ngs/5_export_python/export2py.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2012 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/5_export_python/ising.cpp
+++ b/tutorials/ngs/5_export_python/ising.cpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/5_export_python/ising.hpp
+++ b/tutorials/ngs/5_export_python/ising.hpp
@@ -6,22 +6,8 @@
  *                                                                                 *
  * Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   *
  *                                                                                 *
- * This software is part of the ALPS libraries, published under the ALPS           *
- * Library License; you can use, redistribute it and/or modify it under            *
- * the terms of the license, either version 1 or (at your option) any later        *
- * version.                                                                        *
- *                                                                                 *
- * You should have received a copy of the ALPS Library License along with          *
- * the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       *
- * available from http://alps.comp-phys.org/.                                      *
- *                                                                                 *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        *
- * FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       *
- * SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       *
- * FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     *
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     *
- * DEALINGS IN THE SOFTWARE.                                                       *
+ * ALPS Project: https://alps.comp-phys.org/                                       *
+ * SPDX-License-Identifier: MIT                                                    *
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tutorials/ngs/5_export_python/main.py
+++ b/tutorials/ngs/5_export_python/main.py
@@ -5,22 +5,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.hdf5 as hdf5

--- a/tutorials/ngs/6_python_native/ising.py
+++ b/tutorials/ngs/6_python_native/ising.py
@@ -5,22 +5,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.hdf5 as hdf5

--- a/tutorials/ngs/6_python_native/main.py
+++ b/tutorials/ngs/6_python_native/main.py
@@ -5,22 +5,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.hdf5 as hdf5

--- a/tutorials/ngs/7_python_extend/ising.py
+++ b/tutorials/ngs/7_python_extend/ising.py
@@ -5,22 +5,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.ngs as ngs

--- a/tutorials/ngs/7_python_extend/main.py
+++ b/tutorials/ngs/7_python_extend/main.py
@@ -5,22 +5,8 @@
  #                                                                                 #
  # Copyright (C) 2010 - 2013 by Lukas Gamper <gamperl@gmail.com>                   #
  #                                                                                 #
- # This software is part of the ALPS libraries, published under the ALPS           #
- # Library License; you can use, redistribute it and/or modify it under            #
- # the terms of the license, either version 1 or (at your option) any later        #
- # version.                                                                        #
- #                                                                                 #
- # You should have received a copy of the ALPS Library License along with          #
- # the ALPS Libraries; see the file LICENSE.txt. If not, the license is also       #
- # available from http://alps.comp-phys.org/.                                      #
- #                                                                                 #
- #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
- # FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT       #
- # SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE       #
- # FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,     #
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER     #
- # DEALINGS IN THE SOFTWARE.                                                       #
+ # ALPS Project: https://alps.comp-phys.org/                                       #
+ # SPDX-License-Identifier: MIT                                                    #
  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import pyalps.hdf5 as hdf5

--- a/tutorials/notebook/ja/tutorial_ed01a.py
+++ b/tutorials/notebook/ja/tutorial_ed01a.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed02a.py
+++ b/tutorials/notebook/ja/tutorial_ed02a.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed02b.py
+++ b/tutorials/notebook/ja/tutorial_ed02b.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed02c.py
+++ b/tutorials/notebook/ja/tutorial_ed02c.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed03a.py
+++ b/tutorials/notebook/ja/tutorial_ed03a.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed03b.py
+++ b/tutorials/notebook/ja/tutorial_ed03b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed03c.py
+++ b/tutorials/notebook/ja/tutorial_ed03c.py
@@ -5,22 +5,8 @@
 # 
 # Copyright (C) 2010 by Jan Gukelberger <gukelberger@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed04a.py
+++ b/tutorials/notebook/ja/tutorial_ed04a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed04b.py
+++ b/tutorials/notebook/ja/tutorial_ed04b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed05b.py
+++ b/tutorials/notebook/ja/tutorial_ed05b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Bela Bauer <bauerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed06a.py
+++ b/tutorials/notebook/ja/tutorial_ed06a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed06b.py
+++ b/tutorials/notebook/ja/tutorial_ed06b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed06c.py
+++ b/tutorials/notebook/ja/tutorial_ed06c.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_ed06d.py
+++ b/tutorials/notebook/ja/tutorial_ed06d.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc01a_1.py
+++ b/tutorials/notebook/ja/tutorial_mc01a_1.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc01a_2.py
+++ b/tutorials/notebook/ja/tutorial_mc01a_2.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc01b.py
+++ b/tutorials/notebook/ja/tutorial_mc01b.py
@@ -6,22 +6,8 @@
 #                       Ping Nang Ma     <pingnang@phys.ethz.ch> 
 #                       Matthias Troyer  <troyer@phys.ethz.ch>    
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 #
 #############################################################################
 

--- a/tutorials/notebook/ja/tutorial_mc02a.py
+++ b/tutorials/notebook/ja/tutorial_mc02a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc02b.py
+++ b/tutorials/notebook/ja/tutorial_mc02b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc02c.py
+++ b/tutorials/notebook/ja/tutorial_mc02c.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc02d.py
+++ b/tutorials/notebook/ja/tutorial_mc02d.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc02full.py
+++ b/tutorials/notebook/ja/tutorial_mc02full.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc03a.py
+++ b/tutorials/notebook/ja/tutorial_mc03a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc03b.py
+++ b/tutorials/notebook/ja/tutorial_mc03b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc03full.py
+++ b/tutorials/notebook/ja/tutorial_mc03full.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc04.py
+++ b/tutorials/notebook/ja/tutorial_mc04.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc05a.py
+++ b/tutorials/notebook/ja/tutorial_mc05a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc05b.py
+++ b/tutorials/notebook/ja/tutorial_mc05b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc06a.py
+++ b/tutorials/notebook/ja/tutorial_mc06a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc06b.py
+++ b/tutorials/notebook/ja/tutorial_mc06b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc06c.py
+++ b/tutorials/notebook/ja/tutorial_mc06c.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc06d.py
+++ b/tutorials/notebook/ja/tutorial_mc06d.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Matthias Troyer <troyer@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc07a.py
+++ b/tutorials/notebook/ja/tutorial_mc07a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Brigitte Surer <surerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc07b.py
+++ b/tutorials/notebook/ja/tutorial_mc07b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2009-2010 by Brigitte Surer <surerb@phys.ethz.ch> 
 # 
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc08a.py
+++ b/tutorials/notebook/ja/tutorial_mc08a.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Brigitte Surer
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc08b.py
+++ b/tutorials/notebook/ja/tutorial_mc08b.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Brigitte Surer
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/notebook/ja/tutorial_mc08c.py
+++ b/tutorials/notebook/ja/tutorial_mc08c.py
@@ -6,22 +6,8 @@
 # 
 # Copyright (C) 2010 by Brigitte Surer
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 

--- a/tutorials/test_py.py
+++ b/tutorials/test_py.py
@@ -8,22 +8,8 @@ from __future__ import print_function
 # Copyright (C) 2010 by Bela Bauer  <bauerb@gmail.com>
 #                       Matthias Troyer <troyer@itp.phys.ethz.ch>
 #
-# This software is part of the ALPS libraries, published under the ALPS
-# Library License; you can use, redistribute it and/or modify it under
-# the terms of the license, either version 1 or (at your option) any later
-# version.
-#  
-# You should have received a copy of the ALPS Library License along with
-# the ALPS Libraries; see the file LICENSE.txt. If not, the license is also
-# available from http://alps.comp-phys.org/.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT 
-# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE 
-# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-# DEALINGS IN THE SOFTWARE.
+# ALPS Project: https://alps.comp-phys.org/
+# SPDX-License-Identifier: MIT
 # 
 # ****************************************************************************
 


### PR DESCRIPTION
## Summary

Mechanically replace 220 legacy ALPS license blocks and 1,160 full MIT blocks in ALPS Project headers with:

```text
ALPS Project: https://alps.comp-phys.org/
SPDX-License-Identifier: MIT
```

Generated entirely by `script/relicense.py` from #109; there are no manual semantic edits. Copyright lines are retained. The rule leaves 129 unclassified MIT notices and 21 Boost-style grants untouched. **Do not manually review files for this PR. If #109 was accepted, approval of #124 is a no-brainer and just a separate PR for bookkeeping.** 

## Stack

Base: #109, which is based on #123. Merge order: **#123 → #109 → #124**.

Rebasing after #110 drops four already-deleted legacy files, reducing the generated sweep from 1,380 to 1,376 files.

## Reproduce

From this PR's base:

```sh
python3 script/relicense.py --write
python3 script/relicense.py --check
git diff --check
```

## Validation

- 1 commit; 1,380 files; exactly 1 replacement per file
- 2,760 insertions; 23,240 deletions
- Every changed file matches the generator output byte-for-byte
- `--check` and a second dry run both report 0 files
- `git diff --check`

Related: #108, #109, #123
