### PR TITLE
ci: bound apt and wget operations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ jobs:
   linux-build:
     name: Build ALPS on ${{ matrix.plat.os }}
     runs-on: ${{ matrix.plat.os }}
+    # Worst observed healthy job is ~60 min cold; a hang otherwise burns the
+    # 6-hour GitHub default.
+    timeout-minutes: 90
     strategy:
       matrix:
         plat:
@@ -69,7 +72,13 @@ jobs:
         with:
           python-version: ${{ matrix.plat.py_version }}
       - name: Install dependencies
+        # A wedged mirror must fail the step in minutes, not hang the job to
+        # its 90-minute cap (observed multi-hour stalls in this step).
+        timeout-minutes: 20
         run: |
+          # Bound every apt network operation: 30 s socket timeout, 3 retries.
+          printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+            | sudo tee /etc/apt/apt.conf.d/99ci-timeouts > /dev/null
           sudo apt-get update
           python -m pip install --upgrade pip
           pip install "numpy>=1.26" "scipy>=1.13"
@@ -77,7 +86,8 @@ jobs:
           # Clang >= 19: not in Ubuntu's default apt repos; use apt.llvm.org.
           # GCC >= 15: not in Ubuntu's default apt repos; use ubuntu-toolchain-r PPA.
           if [[ "${{ matrix.plat.c_compiler }}" == "clang" && "${{ matrix.plat.c_version }}" -ge 19 ]]; then
-            wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- ${{ matrix.plat.c_version }} all
+            wget -nv --tries=3 --timeout=60 -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+            sudo bash /tmp/llvm.sh ${{ matrix.plat.c_version }} all
           else
             if [[ "${{ matrix.plat.c_compiler }}" == "gcc" && "${{ matrix.plat.c_version }}" -ge 15 ]]; then
               sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -85,7 +95,7 @@ jobs:
             fi
             sudo apt install ${{ matrix.plat.comp_pack }}
           fi
-          wget https://archives.boost.io/release/1.${{ matrix.plat.boost_version }}.0/source/boost_1_${{ matrix.plat.boost_version }}_0.tar.gz
+          wget -nv --tries=3 --timeout=60 --waitretry=10 https://archives.boost.io/release/1.${{ matrix.plat.boost_version }}.0/source/boost_1_${{ matrix.plat.boost_version }}_0.tar.gz
           tar -xzf boost_1_${{ matrix.plat.boost_version }}_0.tar.gz
       - name: Build ALPS
         env:
@@ -102,6 +112,8 @@ jobs:
   macos-build:
     name: Build ALPS on ${{ matrix.plat.os }} / ${{ matrix.plat.c_compiler }}
     runs-on: ${{ matrix.plat.os }}
+    # Intel runners are slow and variable; worst observed healthy job ~85 min.
+    timeout-minutes: 120
     strategy:
       matrix:
         plat:
@@ -122,6 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
+        timeout-minutes: 30
         run: |
           brew install python@${{ matrix.plat.py_version }} gfortran
           pip${{ matrix.plat.py_version }} install "numpy>=1.26" "scipy>=1.13" --break-system-packages
@@ -129,7 +142,7 @@ jobs:
           if [[ -n "${{ matrix.plat.comp_pack }}" ]]; then
             brew install ${{ matrix.plat.comp_pack }}
           fi
-          wget https://archives.boost.io/release/1.${{ matrix.plat.boost_version }}.0/source/boost_1_${{ matrix.plat.boost_version }}_0.tar.gz
+          wget -nv --tries=3 --timeout=60 --waitretry=10 https://archives.boost.io/release/1.${{ matrix.plat.boost_version }}.0/source/boost_1_${{ matrix.plat.boost_version }}_0.tar.gz
           tar -xzf boost_1_${{ matrix.plat.boost_version }}_0.tar.gz
           ln -sf $(brew --prefix)/bin/python${{ matrix.plat.py_version }} $(brew --prefix)/bin/python
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,8 +28,11 @@ jobs:
 
       # Install Fortran compiler based on OS
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           if [ "${{ matrix.plat.os }}" = "ubuntu-latest" ]; then
+            printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+              | sudo tee /etc/apt/apt.conf.d/99ci-timeouts > /dev/null
             sudo apt-get update
             sudo apt-get install -y gfortran
           else


### PR DESCRIPTION
## Problem addressed 
Occasionally CI jobs fail due to network timeouts (on apt update and wget). When it happens the CI runs to its maximum of 6 hours before the job gets killed, hung on that step. This PR adds timeout and retry guards, such that these jobs can succeed or fail within minutes with a clear error message. 

## Summary

- configure apt with three retries and 30-second HTTP/HTTPS socket timeouts
- bound the LLVM and Boost downloads with explicit wget retry and timeout options
- cap dependency-install steps and overall Linux/macOS jobs so network stalls fail promptly
- apply the same apt protection to the wheel-build dependency step

## Validation

- `actionlint -ignore shellcheck .github/workflows/build.yml .github/workflows/build_wheels.yml`
- `git diff --check`
- audited every apt update and wget call in both workflows for bounded network behavior
