### PR TITLE
Add recommended citation banner to looper

### DIFF
--- a/applications/qmc/looper/looper/version.h
+++ b/applications/qmc/looper/looper/version.h
@@ -25,7 +25,17 @@
 #define LOOPER_COPYRIGHT LOOPER_VERSION_STRING "\n" \
   "  multi-cluster quantum Monte Carlo algorithms for spin systems\n" \
   "  available from http://wistaria.comp-phys.org/alps-looper/\n" \
-  "  copyright (c) 1997-2010 by Synge Todo <wistaria@comp-phys.org>\n" \
+  "  copyright (c) 1997-2010 by Synge Todo <wistaria@comp-phys.org>\n\n" \
+  "********************************************************************\n" \
+  "* Recommended citation in scientific publications:                 *\n" \
+  "* This code used the ALPS [1] implementation [2] of the loop       *\n" \
+  "* algorithm [3-5].                                                 *\n" \
+  "* [1] JSTAT (2011) P05001;                                         *\n" \
+  "* [2] Phys. Rev. Lett. 87, 047203 (2001)                           *\n" \
+  "* [3] Phys. Rev. Lett. 70, 875 (1993)                              *\n" \
+  "* [4] Phys. Rev. Lett. 77, 5130 (1996)                             *\n" \
+  "* [5] Adv. Phys. 52, 1 (2003)                                      *\n" \
+  "********************************************************************\n" \
 
 #include <alps/utility/copyright.hpp>
 #include <iostream>


### PR DESCRIPTION
## Summary
- add a recommended-citation box to the looper copyright output
- cite the ALPS paper, the looper implementation paper, and the three algorithm papers listed in the ALPS documentation

## Testing
- `cmake --build build --target loop -j2`