### PR TITLE
Set fermion sign in new operation

### DIFF
--- a/applications/dmrg/dmrg/dmrg.h
+++ b/applications/dmrg/dmrg/dmrg.h
@@ -593,6 +593,7 @@ DMRGTask<value_type>::create_site_operator(std::string const& name, alps::SiteOp
     new_op.dqn = dqn;
     new_op.resize(block.basis());
     new_op = dest;
+    new_op.set_fermion(dqn.fermion_sign() == -1);
     block.push_back(new_op);
     return new_op;
   }


### PR DESCRIPTION
Fermion flag was missing, so spinless fermions were getting very wrong results.

As a follow up to this, more unit tests might be necessary for dmrg.

## Summary

In making a tutorial for spinless fermions I saw that hardcore bosons performed as expected, while bonfied spinless fermions did not. This remained true for a lattice with a single site. 

Diging into this it was revealed the Hamiltonian was not Hermitian. Changing this flag resulted in the results to converge to the known answer for the GS energy of a free chain.

I tested the lattice and Hamiltonian by:
i.) Running dmrg on the lattice with hardcore bosons (correct result)
ii.) Running ED with the lattice and spinless fermions (correct result)
iii.) Running dmrg with the lattice and spinless fermions (incorrect result)
iv.) After updating the flag, iii worked fine

## Testing
Using the attached .md file (the spinless fermion tutorial of interest), test this issue on the old vs new code. The .md file for the tutorial is attached here where the lattice and parameters are defined. It might be a good idea to build your own lattice and Hamiltonian to check against what I did.

[dmrg09.md](https://github.com/user-attachments/files/31483729/dmrg09.md)


## Type of change

<!-- Check all that apply -->

- [ ] Bug fix

## Testing

<!-- How was this tested? Check all that apply and describe any manual steps. -->

- [ ] Results verified against known reference values or published results
- [ ] Tested on macOS
- [ ] Tested on Linux

## For simulation code changes

<!-- If this PR adds or modifies a simulation method, please complete this section. Skip if not applicable. -->

- [ ] Physical results match expected behaviour (describe briefly below)


<!-- Brief description of physical validation, if applicable: -->

## Checklist

- [ ] No new compiler warnings (`-Wall -Wextra`)
- [ ] Commit messages are descriptive and in the imperative mood

## Related issues

<!-- Link any related issues: "Closes #...", "Related to #..." -->
