### PR TITLE
Publish CPython 3.14 wheels and document Windows/WSL installation (#118)

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -40,10 +40,13 @@ jobs:
             brew install gfortran
           fi
 
+      # cibuildwheel >= 3.0 is needed for CPython 3.14.  Without a cp314
+      # wheel, pip on Python 3.14 silently falls back to compiling pyALPS and
+      # Boost from the sdist, which is what killed the WSL install in #118.
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v4.2.0
         env:
-          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
           CIBW_ARCHS: ${{ matrix.plat.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.plat.arch }}
 

--- a/README-py.md
+++ b/README-py.md
@@ -6,12 +6,33 @@ This is python packages for `Algorithms and Libraries for Physics Simulations` p
 
 ### Installation instruction from binaries
 
-1. pyALPS can be installed on most Linux and MacOS mcachines from prebuilt biniaries available on [PyPi](https://pypi.org/project/pyalps).
+1. pyALPS can be installed on most Linux and MacOS machines from prebuilt binaries available on [PyPI](https://pypi.org/project/pyalps).
 pyALPS can be installed using `pip` Python package manager:
 
 ```
 pip install pyalps
 ```
+
+Wheels are published for CPython on x86_64 Linux (manylinux) and Apple-silicon macOS; the Python versions covered by a release are listed under "Download files" on PyPI. If no wheel matches your interpreter, `pip` silently falls back to compiling pyALPS **and Boost** from the source distribution, which takes an hour or more and several gigabytes of memory. To make `pip` stop with a clear message instead, install with
+
+```
+pip install --only-binary=:all: pyalps
+```
+
+### Installation on Windows
+
+pyALPS has no native Windows build. Use the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/install) (WSL 2) with a Linux distribution such as Ubuntu, create a virtual environment inside WSL with a Python version for which a Linux wheel exists (see above), and run the `pip install` command there.
+
+If the installation is killed while "Building wheel for pyalps", `pip` found no wheel and started a source build that ran out of memory; WSL becoming unresponsive at the same time is the usual symptom. Switch to a supported Python version or, if you do want to build from source inside WSL, first give the VM enough memory by creating `%USERPROFILE%\.wslconfig` on the Windows side:
+
+```
+[wsl2]
+memory=12GB
+swap=32GB
+processors=4
+```
+
+Run `wsl --shutdown` from PowerShell, reopen the WSL terminal, and follow the source-build instructions below. Note that the pyalps 2.3.3 source distribution on PyPI does not build with scikit-build-core 0.10 or newer (`ERROR: Use build.verbose instead of cmake.verbose`); build from a Git checkout as described below instead.
 
 ### Installation instruction from sources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: Implementation :: CPython',
     "Operating System :: POSIX",


### PR DESCRIPTION
## Summary

The Windows user in #118 installed pyalps inside WSL with Python 3.14. No cp314 wheel exists, so pip silently compiled pyALPS and Boost from the 2.3.3 sdist until WSL ran out of memory; the retry then hit the sdist's stale `cmake.verbose` setting, which scikit-build-core >= 0.10 rejects.

- build cp314 wheels: cibuildwheel 2.22.0 -> 4.2.0 (3.14 needs >= 3.0) and `cp314-*` in `CIBW_BUILD`; the explicit list keeps the free-threaded builds off. Add the trove classifier.
- `README-py.md`: state which platforms get wheels, recommend `pip install --only-binary=:all: pyalps` to fail fast instead of starting an hour-long source build, and add a Windows section (WSL 2, supported Python versions, the `.wslconfig` memory settings, and that the 2.3.3 sdist needs a Git checkout to build with current scikit-build-core)

## Testing

- `actionlint` on the workflow; `pyproject.toml` parses
- the cp314 wheels themselves are verified by this PR's wheel CI run; `build.yml` already builds Python 3.14 with Boost 1.87 to 1.91 on Linux and macOS

Related to #118
